### PR TITLE
v1.0.6: Security hardening — close 8 audit findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,89 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.0.6] — 2026-04-27
+
+Security hardening release. Closes 8 actionable findings from the
+2026-04-27 multi-tool audit (semgrep + trivy + gitleaks + bandit +
+pip-audit + manual review by the security-engineer agent + Opus 4.7).
+No public API changes; behavior unchanged for legitimate inputs.
+
+### Security
+
+- **F1 (HIGH)** SSRF: replaced `trafilatura.fetch_url` and the bare
+  `urllib.request.urlopen` paths with a new `any2md/_http.py` module
+  that does manual redirect walking with per-hop revalidation. Defends
+  against DNS-rebinding and redirect-based bypass of the IP-class
+  check. New `validate_url` rejects non-http(s) schemes and
+  private/loopback/link-local/reserved targets. 20 MB body cap, 3-hop
+  redirect cap, redirect-loop detection. Applied to `convert_url`,
+  `_http_last_modified`, and `arxiv_lookup`.
+- **F5 (MED)** `--meta` integrity: `content_hash`, `extracted_via`,
+  `source_file`, `lane`, `token_estimate`, `recommended_chunk_level`
+  are now **reserved** and silently filtered from `--meta` /
+  `--meta-file` / `.any2md.toml` overrides with a stderr `WARN` per
+  drop. Defense-in-depth filter also runs inside `frontmatter.compose`.
+- **F3 (MED)** TOML auto-discovery now stops at the first ancestor
+  containing `.git` / `pyproject.toml` / `setup.py` / `setup.cfg` /
+  `package.json` / `.any2md.toml.boundary`. New `--no-config` flag
+  fully disables discovery.
+- **F4 (MED)** DOCX zip-bomb: `_safe_zip_open` enforces a 1 MB cap on
+  the declared uncompressed size of `core.xml` and `app.xml` before
+  parsing. Oversized members raise `ValueError` → clean per-file FAIL.
+- **F-CVE (MED)** Dependency floors bumped: `lxml>=6.1.0,<7`
+  (CVE-2026-41066), `pillow>=12.2.0,<13` (CVE-2026-25990,
+  CVE-2026-40192), `urllib3>=2.6.3,<3` (CVE-2026-21441). All ranges
+  acquire upper bounds (compat envelope). `requirements.txt` becomes
+  a development/CI lockfile with exact pins.
+- **F6 (LOW)** Atomic writes: new `any2md.utils.atomic_write_text`
+  writes via `tempfile.mkstemp` + `os.replace`. Refuses to overwrite
+  a pre-existing symlink at the output path. Wired through
+  `pdf/docx/html/txt` converters; PDF image extraction adds a symlink
+  check before `pil_image.save`.
+- **F2 (LOW)** Control-char sanitizer strips C0/C1 controls (preserves
+  `\t`, `\n`) from captured Docling `msword_backend` warnings before
+  forwarding them to `collected_warnings()` and stderr. Defends
+  terminals from ANSI-escape spoofing.
+- **F11 (LOW)** PDF image-dir name now goes through `safe_dir_name`
+  (alphanumeric/`_`/`-` only). Closes a `Path.stem == ".."` corner
+  case that co-mingled images with markdown outputs.
+- **XXE defense-in-depth**: migrated `xml.etree.ElementTree` →
+  `defusedxml.ElementTree` in `docx.py` and `heuristics.py`. Stdlib
+  was already safe in Python 3.7+; this silences bandit B405/B314
+  permanently and protects against future stdlib regressions.
+
+### Added
+
+- New module `any2md/_http.py` (`validate_url`, `safe_fetch`).
+- New CLI flag `--no-config`.
+- New helpers `any2md.utils.atomic_write_text` and `safe_dir_name`.
+- New runtime dependency: `defusedxml>=0.7.1,<1`.
+
+### Tests
+
+- 7 new unit-test files (40 new tests): `test_http_safe.py`,
+  `test_meta_reserved_keys.py`, `test_config_walkup.py`,
+  `test_zipbomb_guard.py`, `test_atomic_write.py`,
+  `test_safe_dir_name.py`, `test_log_sanitizer.py`.
+- Existing 290 tests continue to pass.
+- Bandit audit went from **9 findings** (3 medium, 6 low) to **1 low**
+  (legitimate `try/except/pass` in arxiv `_warn`).
+- 5-DOCX regression run reproduces v1.0.5 word counts exactly
+  (978/6726/15566/7811/1477).
+
+### Audit summary
+
+| ID | Title | Severity |
+|----|-------|----------|
+| F1 | SSRF: DNS rebind + redirect bypass | High |
+| F5 | `--meta` clobbers reserved frontmatter | Medium |
+| F3 | TOML discovery walks above project root | Medium |
+| F4 | DOCX zip-bomb amplification | Medium |
+| F-CVE | Transitive deps with known CVEs | Medium |
+| F6 | Symlink-following on output writes | Low |
+| F2 | Control-char passthrough in Docling logs | Low |
+| F11 | PDF stem `..` corner case | Low |
+
 ## [1.0.5] — 2026-04-27
 
 Patch release. Recovers DOCX content that Docling's msword backend

--- a/any2md/__init__.py
+++ b/any2md/__init__.py
@@ -1,3 +1,3 @@
 """Convert PDF, DOCX, HTML, and TXT files to LLM-optimized Markdown."""
 
-__version__ = "1.0.5"
+__version__ = "1.0.6"

--- a/any2md/_http.py
+++ b/any2md/_http.py
@@ -1,0 +1,108 @@
+"""SSRF-safe HTTP fetching utilities for any2md.
+
+Centralizes URL scheme + IP validation and provides a fetcher that
+walks redirects manually and revalidates the host on each hop. This
+defends against:
+  - DNS rebinding (host -> public IP for validator, private IP for fetch)
+  - Redirect-based SSRF (public landing page -> 302 to 169.254.169.254)
+  - Non-http(s) schemes (file://, gopher://, etc.)
+  - Decompression / huge-response DoS (response-size cap)
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
+
+_MAX_REDIRECT_HOPS = 3
+_FETCH_TIMEOUT = 15  # seconds
+_MAX_RESPONSE_BYTES = 20 * 1024 * 1024  # 20 MB cap on body read
+_USER_AGENT = "any2md/1.0.6"
+
+
+def validate_url(url: str) -> str | None:
+    """Validate URL scheme + host. Returns an error message or None.
+
+    One-shot DNS lookup; rebind protection requires re-checking on
+    every redirect hop (handled by ``safe_fetch``).
+    """
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return f"unsupported scheme: {parsed.scheme!r}"
+    if not parsed.hostname:
+        return f"no hostname in URL: {url}"
+    try:
+        infos = socket.getaddrinfo(
+            parsed.hostname, None, type=socket.SOCK_STREAM
+        )
+    except socket.gaierror:
+        return f"cannot resolve host: {parsed.hostname}"
+    for *_, sockaddr in infos:
+        try:
+            addr = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            continue
+        if (
+            addr.is_private
+            or addr.is_reserved
+            or addr.is_loopback
+            or addr.is_link_local
+        ):
+            return f"URL resolves to disallowed address: {addr}"
+    return None
+
+
+class _NoFollowRedirect(urllib.request.HTTPRedirectHandler):
+    """Disable urllib's automatic redirect following."""
+
+    def redirect_request(self, *args, **kwargs):  # noqa: ARG002
+        return None
+
+
+def safe_fetch(
+    url: str,
+    *,
+    method: str = "GET",
+    max_hops: int = _MAX_REDIRECT_HOPS,
+) -> tuple[bytes | None, dict | None, str | None]:
+    """Fetch ``url`` with manual redirect walking + per-hop revalidation.
+
+    Returns ``(body, headers, None)`` on 2xx, or ``(None, None, error)``
+    on rejection / failure. ``headers`` is the response headers as a
+    plain ``dict``.
+    """
+    visited: list[str] = []
+    current = url
+    opener = urllib.request.build_opener(_NoFollowRedirect())
+    for hop in range(max_hops + 1):
+        if current in visited:
+            return None, None, "redirect loop"
+        visited.append(current)
+        err = validate_url(current)
+        if err:
+            return None, None, err
+        req = urllib.request.Request(
+            current, method=method, headers={"User-Agent": _USER_AGENT}
+        )
+        try:
+            resp = opener.open(req, timeout=_FETCH_TIMEOUT)
+        except urllib.error.HTTPError as e:
+            if e.code in (301, 302, 303, 307, 308):
+                if hop >= max_hops:
+                    return None, None, f"too many redirects (>{max_hops})"
+                location = e.headers.get("Location") if e.headers else None
+                if not location:
+                    return None, None, f"HTTP {e.code} without Location"
+                current = urllib.parse.urljoin(current, location)
+                continue
+            return None, None, f"HTTP {e.code}"
+        except (urllib.error.URLError, OSError, TimeoutError) as e:
+            return None, None, f"fetch error: {e}"
+        body = resp.read(_MAX_RESPONSE_BYTES + 1)
+        if len(body) > _MAX_RESPONSE_BYTES:
+            return None, None, f"response exceeds {_MAX_RESPONSE_BYTES} bytes"
+        return body, dict(resp.headers), None
+    return None, None, f"too many redirects (>{max_hops})"

--- a/any2md/_http.py
+++ b/any2md/_http.py
@@ -35,9 +35,7 @@ def validate_url(url: str) -> str | None:
     if not parsed.hostname:
         return f"no hostname in URL: {url}"
     try:
-        infos = socket.getaddrinfo(
-            parsed.hostname, None, type=socket.SOCK_STREAM
-        )
+        infos = socket.getaddrinfo(parsed.hostname, None, type=socket.SOCK_STREAM)
     except socket.gaierror:
         return f"cannot resolve host: {parsed.hostname}"
     for *_, sockaddr in infos:

--- a/any2md/cli.py
+++ b/any2md/cli.py
@@ -20,6 +20,7 @@ from any2md.converters import (
     set_output_mode,
 )
 from any2md.converters.html import convert_url
+from any2md.frontmatter import filter_reserved_overrides
 from any2md.pipeline import PipelineOptions
 from any2md.utils import sanitize_filename, url_to_filename
 
@@ -249,6 +250,9 @@ def main():
         print(f"Error: {e}", file=sys.stderr)
         sys.exit(1)
     overrides = _deep_merge_overrides(overrides, cli_meta)
+    overrides = filter_reserved_overrides(
+        overrides, source_label="--meta/--meta-file/.any2md.toml"
+    )
 
     if (
         args.high_fidelity

--- a/any2md/cli.py
+++ b/any2md/cli.py
@@ -171,6 +171,11 @@ def main():
         help="Promote pipeline validation warnings to errors (exit 3).",
     )
     parser.add_argument(
+        "--no-config",
+        action="store_true",
+        help="Skip .any2md.toml auto-discovery (overrides default walk-up).",
+    )
+    parser.add_argument(
         "--docx-fallback-on-warn",
         action=argparse.BooleanOptionalAction,
         default=True,
@@ -223,7 +228,7 @@ def main():
     overrides: dict[str, Any] = {}
     auto_id_prefix, auto_id_type_code = "LOCAL", "DOC"
 
-    discovered = discover_config()
+    discovered = None if args.no_config else discover_config()
     if discovered is not None:
         cfg = load_toml(discovered)
         overrides = _deep_merge_overrides(overrides, extract_meta_overrides(cfg))

--- a/any2md/config.py
+++ b/any2md/config.py
@@ -42,17 +42,31 @@ def load_toml(path: Path) -> dict[str, Any]:
         return {}
 
 
+_PROJECT_BOUNDARY_MARKERS = (
+    ".git",
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "package.json",
+    ".any2md.toml.boundary",
+)
+
+
 def discover_config(start: Path | None = None) -> Path | None:
     """Walk up from ``start`` (default: cwd) looking for ``.any2md.toml``.
 
-    Returns the first match found or ``None`` if no config exists in
-    any ancestor directory.
+    Stops at the first ancestor containing a project boundary marker
+    (``.git``, ``pyproject.toml``, ``setup.py``, ``setup.cfg``,
+    ``package.json``, or ``.any2md.toml.boundary``) so config in
+    unrelated parent directories cannot leak into a project's run.
     """
     cur = (start or Path.cwd()).resolve()
     while True:
         candidate = cur / ".any2md.toml"
         if candidate.is_file():
             return candidate
+        if any((cur / m).exists() for m in _PROJECT_BOUNDARY_MARKERS):
+            return None
         if cur.parent == cur:
             return None
         cur = cur.parent

--- a/any2md/converters/docx.py
+++ b/any2md/converters/docx.py
@@ -10,6 +10,7 @@ produces the markdown body.
 from __future__ import annotations
 
 import logging
+import re
 import sys
 import zipfile
 
@@ -31,6 +32,18 @@ from any2md.utils import atomic_write_text, sanitize_filename
 
 
 _DOCLING_MSWORD_LOGGER = "docling.backend.msword_backend"
+
+_LOG_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+
+
+def _sanitize_log_text(s: str) -> str:
+    """Strip ASCII C0/C1 control chars from a log message before re-emission.
+
+    Defends terminals from ANSI-escape spoofing planted in malicious DOCX
+    content that surfaces as a Docling msword_backend warning. ``\\t``
+    and ``\\n`` are preserved (not in the strip class).
+    """
+    return _LOG_CONTROL_CHARS_RE.sub("", s)
 
 _MAX_DOCX_METADATA_SIZE = 1 * 1024 * 1024  # 1 MB; core.xml/app.xml are typically <10 KB
 
@@ -253,7 +266,12 @@ def convert_docx(
             md_text, _ = _extract_via_mammoth(docx_path, options)
             extracted_via = "docling→mammoth (warning fallback)"
             lane = "text"
-            add_warnings([f"docling.msword_backend: {m}" for m in docling_warnings])
+            add_warnings(
+                [
+                    f"docling.msword_backend: {_sanitize_log_text(m)}"
+                    for m in docling_warnings
+                ]
+            )
 
         md_text, warnings = pipeline.run(md_text, lane, options)
         add_warnings(warnings)

--- a/any2md/converters/docx.py
+++ b/any2md/converters/docx.py
@@ -11,8 +11,10 @@ from __future__ import annotations
 
 import logging
 import sys
-import xml.etree.ElementTree as ET
 import zipfile
+
+from defusedxml.ElementTree import ParseError as _XmlParseError
+from defusedxml.ElementTree import parse as _xml_parse
 from datetime import date
 from pathlib import Path
 
@@ -90,7 +92,7 @@ def _read_docx_metadata(docx_path: Path) -> dict[str, object]:
         with zipfile.ZipFile(docx_path) as z:
             try:
                 with z.open("docProps/core.xml") as f:
-                    root = ET.parse(f).getroot()
+                    root = _xml_parse(f).getroot()
                 title = root.findtext("dc:title", namespaces=_NS_CORE)
                 if title:
                     out["title_hint"] = title.strip()
@@ -106,7 +108,7 @@ def _read_docx_metadata(docx_path: Path) -> dict[str, object]:
                 pass
             try:
                 with z.open("docProps/app.xml") as f:
-                    root = ET.parse(f).getroot()
+                    root = _xml_parse(f).getroot()
                 company = root.findtext("ext:Company", namespaces=_NS_APP)
                 application = root.findtext("ext:Application", namespaces=_NS_APP)
                 # v1.0.2: Company takes priority for `organization` (real
@@ -126,7 +128,7 @@ def _read_docx_metadata(docx_path: Path) -> dict[str, object]:
                     out["produced_by"] = app_result.produced_by
             except KeyError:
                 pass
-    except (zipfile.BadZipFile, ET.ParseError):
+    except (zipfile.BadZipFile, _XmlParseError):
         pass
     return out
 

--- a/any2md/converters/docx.py
+++ b/any2md/converters/docx.py
@@ -27,7 +27,7 @@ from any2md.converters import add_warnings, is_quiet
 from any2md.frontmatter import SourceMeta, compose
 from any2md.heuristics import filter_organization
 from any2md.pipeline import PipelineOptions
-from any2md.utils import sanitize_filename
+from any2md.utils import atomic_write_text, sanitize_filename
 
 
 _DOCLING_MSWORD_LOGGER = "docling.backend.msword_backend"
@@ -280,7 +280,7 @@ def convert_docx(
         full = compose(md_text, meta, options, overrides=options.frontmatter_overrides)
 
         output_dir.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(full, encoding="utf-8", newline="\n")
+        atomic_write_text(out_path, full)
         wc = meta.word_count or 0
         suffix = f", {len(warnings)} warning(s)" if warnings else ""
         if not is_quiet():

--- a/any2md/converters/docx.py
+++ b/any2md/converters/docx.py
@@ -32,6 +32,24 @@ from any2md.utils import sanitize_filename
 
 _DOCLING_MSWORD_LOGGER = "docling.backend.msword_backend"
 
+_MAX_DOCX_METADATA_SIZE = 1 * 1024 * 1024  # 1 MB; core.xml/app.xml are typically <10 KB
+
+
+def _safe_zip_open(z: zipfile.ZipFile, name: str, max_size: int = _MAX_DOCX_METADATA_SIZE):
+    """Open a fixed-name DOCX member after a declared-size sanity check.
+
+    Defends against zip-bomb amplification: a malicious DOCX can declare
+    an uncompressed_size of 10 GB for ``core.xml`` and bomb the XML
+    parser. Raises ``ValueError`` (caught by ``convert_docx``'s existing
+    handler -> file fails cleanly).
+    """
+    info = z.getinfo(name)
+    if info.file_size > max_size:
+        raise ValueError(
+            f"{name} declared size {info.file_size} exceeds {max_size}-byte limit"
+        )
+    return z.open(name)
+
 
 class _DoclingMswordWarningCapture:
     """Buffer WARNING+ records from Docling's DOCX backend logger.
@@ -91,7 +109,7 @@ def _read_docx_metadata(docx_path: Path) -> dict[str, object]:
     try:
         with zipfile.ZipFile(docx_path) as z:
             try:
-                with z.open("docProps/core.xml") as f:
+                with _safe_zip_open(z, "docProps/core.xml") as f:
                     root = _xml_parse(f).getroot()
                 title = root.findtext("dc:title", namespaces=_NS_CORE)
                 if title:
@@ -107,7 +125,7 @@ def _read_docx_metadata(docx_path: Path) -> dict[str, object]:
             except KeyError:
                 pass
             try:
-                with z.open("docProps/app.xml") as f:
+                with _safe_zip_open(z, "docProps/app.xml") as f:
                     root = _xml_parse(f).getroot()
                 company = root.findtext("ext:Company", namespaces=_NS_APP)
                 application = root.findtext("ext:Application", namespaces=_NS_APP)

--- a/any2md/converters/docx.py
+++ b/any2md/converters/docx.py
@@ -45,10 +45,13 @@ def _sanitize_log_text(s: str) -> str:
     """
     return _LOG_CONTROL_CHARS_RE.sub("", s)
 
+
 _MAX_DOCX_METADATA_SIZE = 1 * 1024 * 1024  # 1 MB; core.xml/app.xml are typically <10 KB
 
 
-def _safe_zip_open(z: zipfile.ZipFile, name: str, max_size: int = _MAX_DOCX_METADATA_SIZE):
+def _safe_zip_open(
+    z: zipfile.ZipFile, name: str, max_size: int = _MAX_DOCX_METADATA_SIZE
+):
     """Open a fixed-name DOCX member after a declared-size sanity check.
 
     Defends against zip-bomb amplification: a malicious DOCX can declare

--- a/any2md/converters/html.py
+++ b/any2md/converters/html.py
@@ -2,12 +2,9 @@
 
 from __future__ import annotations
 
-import ipaddress
-import socket
 import sys
-import urllib.parse
-import urllib.request
 from datetime import date
+from email.utils import parsedate_to_datetime
 from pathlib import Path
 
 import markdownify
@@ -15,87 +12,51 @@ import trafilatura
 from bs4 import BeautifulSoup
 
 from any2md import pipeline
+from any2md._http import safe_fetch
 from any2md.converters import add_warnings, is_quiet
 from any2md.frontmatter import SourceMeta, compose
 from any2md.pipeline import PipelineOptions
 from any2md.utils import (
+    atomic_write_text,
     read_text_with_fallback,
     sanitize_filename,
     url_to_filename,
 )
 
+
 _MAX_FILE_SIZE = 100 * 1024 * 1024
 
 
-def _validate_url_host(url: str) -> str | None:
-    """Validate that a URL does not point to a private/reserved IP.
-
-    Returns an error message if the host is disallowed, or None if safe.
-    """
-    parsed = urllib.parse.urlparse(url)
-    hostname = parsed.hostname
-    if not hostname:
-        return f"No hostname in URL: {url}"
-    try:
-        infos = socket.getaddrinfo(hostname, None, socket.AF_UNSPEC, socket.SOCK_STREAM)
-    except socket.gaierror:
-        return f"Cannot resolve hostname: {hostname}"
-    for _family, _type, _proto, _canon, sockaddr in infos:
-        ip_str = sockaddr[0]
-        try:
-            addr = ipaddress.ip_address(ip_str)
-        except ValueError:
-            continue
-        if (
-            addr.is_private
-            or addr.is_reserved
-            or addr.is_loopback
-            or addr.is_link_local
-        ):
-            return f"URL resolves to disallowed address: {ip_str}"
-    return None
-
-
 def fetch_url(url: str) -> tuple[str | None, str | None]:
-    """Fetch HTML content from a URL.
+    """Fetch HTML from a URL using the SSRF-safe fetcher.
 
-    Only http and https schemes are accepted. SSRF protection blocks
-    requests to private/reserved/loopback addresses.
-
-    Returns (html_string, None) on success or (None, error_message) on failure.
+    Returns (html_string, None) on success or (None, error_message)
+    on failure. Per-hop host revalidation defends against DNS rebind
+    via redirects.
     """
-    parsed = urllib.parse.urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        return None, f"Unsupported URL scheme: {parsed.scheme!r}"
-    err = _validate_url_host(url)
+    body, _headers, err = safe_fetch(url)
     if err:
         return None, err
-    try:
-        html = trafilatura.fetch_url(url)
-        if html is None:
-            return None, f"Failed to fetch URL: {url}"
-        return html, None
-    except Exception as e:  # noqa: BLE001
-        return None, f"Error fetching URL: {e}"
+    if body is None:
+        return None, f"empty body for {url}"
+    return body.decode("utf-8", errors="replace"), None
 
 
 def _http_last_modified(url: str) -> str | None:
-    """Single HEAD request for Last-Modified. Best-effort."""
-    try:
-        req = urllib.request.Request(
-            url,
-            method="HEAD",
-            headers={"User-Agent": "any2md/1.0"},
-        )
-        with urllib.request.urlopen(req, timeout=10) as resp:
-            lm = resp.headers.get("Last-Modified")
-            if lm:
-                from email.utils import parsedate_to_datetime
+    """Single HEAD request for Last-Modified. Best-effort.
 
-                return parsedate_to_datetime(lm).date().isoformat()
-    except Exception:  # noqa: BLE001
-        pass
-    return None
+    SSRF-safe: same scheme + IP validation as ``fetch_url``.
+    """
+    _body, headers, err = safe_fetch(url, method="HEAD")
+    if err or not headers:
+        return None
+    lm = headers.get("Last-Modified")
+    if not lm:
+        return None
+    try:
+        return parsedate_to_datetime(lm).date().isoformat()
+    except (TypeError, ValueError):
+        return None
 
 
 def _bs4_preclean(html: str) -> str:
@@ -227,7 +188,7 @@ def convert_html(
         full = compose(md_text, meta, options, overrides=options.frontmatter_overrides)
 
         output_dir.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(full, encoding="utf-8", newline="\n")
+        atomic_write_text(out_path, full)
         wc = meta.word_count or 0
         suffix = f", {len(warnings)} warning(s)" if warnings else ""
         if not is_quiet():

--- a/any2md/converters/pdf.py
+++ b/any2md/converters/pdf.py
@@ -22,7 +22,7 @@ from any2md.converters import add_warnings, is_quiet
 from any2md.frontmatter import SourceMeta, compose
 from any2md.heuristics import filter_organization
 from any2md.pipeline import PipelineOptions
-from any2md.utils import sanitize_filename
+from any2md.utils import safe_dir_name, sanitize_filename
 
 
 def _parse_pdf_authors(raw: str | None) -> list[str]:
@@ -140,7 +140,7 @@ def _extract_via_docling(
     if options.save_images:
         pictures = getattr(result.document, "pictures", None) or []
         if pictures:
-            images_dir = output_dir / "images" / pdf_path.stem
+            images_dir = output_dir / "images" / safe_dir_name(pdf_path.stem)
             images_dir.mkdir(parents=True, exist_ok=True)
             for i, picture in enumerate(pictures):
                 try:

--- a/any2md/converters/pdf.py
+++ b/any2md/converters/pdf.py
@@ -22,7 +22,7 @@ from any2md.converters import add_warnings, is_quiet
 from any2md.frontmatter import SourceMeta, compose
 from any2md.heuristics import filter_organization
 from any2md.pipeline import PipelineOptions
-from any2md.utils import safe_dir_name, sanitize_filename
+from any2md.utils import atomic_write_text, safe_dir_name, sanitize_filename
 
 
 def _parse_pdf_authors(raw: str | None) -> list[str]:
@@ -148,6 +148,12 @@ def _extract_via_docling(
                     if pil_image is None:
                         continue
                     img_path = images_dir / f"img{i + 1}.png"
+                    if img_path.exists() and img_path.is_symlink():
+                        print(
+                            f"  WARN: skipping image {i + 1}: target is a symlink.",
+                            file=sys.stderr,
+                        )
+                        continue
                     pil_image.save(str(img_path))
                 except Exception as e:  # noqa: BLE001
                     print(
@@ -265,7 +271,7 @@ def convert_pdf(
         full = compose(md_text, meta, options, overrides=options.frontmatter_overrides)
 
         output_dir.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(full, encoding="utf-8", newline="\n")
+        atomic_write_text(out_path, full)
         suffix = f", {len(warnings)} warning(s)" if warnings else ""
         if not is_quiet():
             print(f"  OK: {out_name} ({page_count} pages, via {extracted_via}{suffix})")

--- a/any2md/converters/txt.py
+++ b/any2md/converters/txt.py
@@ -11,7 +11,7 @@ from any2md import pipeline
 from any2md.converters import add_warnings, is_quiet
 from any2md.frontmatter import SourceMeta, compose
 from any2md.pipeline import PipelineOptions
-from any2md.utils import read_text_with_fallback, sanitize_filename
+from any2md.utils import atomic_write_text, read_text_with_fallback, sanitize_filename
 
 # Existing structurize() heuristic stays in this file from v0.7 — keep it.
 _SEPARATOR_RE = re.compile(r"^([=\-*_~])\1{2,}\s*$")
@@ -199,7 +199,7 @@ def convert_txt(
         full = compose(md_text, meta, options, overrides=options.frontmatter_overrides)
 
         output_dir.mkdir(parents=True, exist_ok=True)
-        out_path.write_text(full, encoding="utf-8", newline="\n")
+        atomic_write_text(out_path, full)
         word_count = meta.word_count or 0
         suffix = f", {len(warnings)} warning(s)" if warnings else ""
         if not is_quiet():

--- a/any2md/frontmatter.py
+++ b/any2md/frontmatter.py
@@ -10,13 +10,53 @@ from __future__ import annotations
 import hashlib
 import math
 import re
+import sys
 import unicodedata
+from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import date as _date_cls
 from typing import Any, Literal
 
 from any2md import heuristics
 from any2md.pipeline import Lane, PipelineOptions
+
+
+_RESERVED_OVERRIDE_KEYS = frozenset(
+    {
+        "content_hash",
+        "token_estimate",
+        "recommended_chunk_level",
+        "extracted_via",
+        "source_file",
+        "lane",
+    }
+)
+
+
+def filter_reserved_overrides(
+    overrides: Mapping[str, Any] | None,
+    *,
+    source_label: str = "overrides",
+) -> dict[str, Any] | None:
+    """Drop top-level reserved keys; emit stderr WARN per drop.
+
+    Reserved keys are derived from the source document and must not be
+    overridable via ``--meta``, ``--meta-file``, or ``.any2md.toml``.
+    Nested dicts under non-reserved keys are returned untouched.
+    """
+    if overrides is None:
+        return None
+    out: dict[str, Any] = {}
+    for k, v in overrides.items():
+        if k in _RESERVED_OVERRIDE_KEYS:
+            print(
+                f"  WARN: ignoring {source_label} key {k!r} "
+                f"— reserved (derived from source).",
+                file=sys.stderr,
+            )
+            continue
+        out[k] = v
+    return out
 
 
 def compute_content_hash(body: str) -> str:
@@ -329,6 +369,7 @@ def compose(
     4. Emit YAML frontmatter in spec §3.2-3.4 order and concatenate the body.
     """
     body = _normalize_body(body)
+    overrides = filter_reserved_overrides(overrides, source_label="compose()")
     fields = _build_fields(body, meta, options)
     if overrides:
         fields = _deep_merge(fields, overrides)

--- a/any2md/heuristics.py
+++ b/any2md/heuristics.py
@@ -531,7 +531,9 @@ def arxiv_lookup(arxiv_id: str, *, timeout: float = 5.0) -> dict | None:
     reserved/loopback). Timeout: 5s default. Single attempt, no retry.
     """
     import urllib.request
-    import xml.etree.ElementTree as ET
+
+    from defusedxml.ElementTree import ParseError as _XmlParseError
+    from defusedxml.ElementTree import fromstring as _xml_fromstring
 
     url = f"https://export.arxiv.org/api/query?id_list={arxiv_id}"
 
@@ -568,8 +570,8 @@ def arxiv_lookup(arxiv_id: str, *, timeout: float = 5.0) -> dict | None:
         return None
 
     try:
-        root = ET.fromstring(data)
-    except ET.ParseError as e:
+        root = _xml_fromstring(data)
+    except _XmlParseError as e:
         _warn(f"arxiv lookup XML parse error for {arxiv_id}: {e}")
         return None
 

--- a/any2md/heuristics.py
+++ b/any2md/heuristics.py
@@ -530,8 +530,6 @@ def arxiv_lookup(arxiv_id: str, *, timeout: float = 5.0) -> dict | None:
     SSRF-guarded same as html.py (validate IPs against private/
     reserved/loopback). Timeout: 5s default. Single attempt, no retry.
     """
-    import urllib.request
-
     from defusedxml.ElementTree import ParseError as _XmlParseError
     from defusedxml.ElementTree import fromstring as _xml_fromstring
 
@@ -546,28 +544,20 @@ def arxiv_lookup(arxiv_id: str, *, timeout: float = 5.0) -> dict | None:
         except Exception:  # noqa: BLE001
             pass
 
-    # SSRF guard (lazy import)
+    # Fetch via shared SSRF-safe helper (handles scheme, IP-class
+    # validation, and per-hop revalidation across redirects).
     try:
-        from any2md.converters.html import _validate_url_host
-
-        err = _validate_url_host(url)
-        if err:
-            _warn(f"arxiv lookup blocked: {err}")
-            return None
+        from any2md._http import safe_fetch
     except Exception as e:  # noqa: BLE001
-        _warn(f"arxiv lookup SSRF check failed: {e}")
+        _warn(f"arxiv lookup _http import failed: {e}")
         return None
-
-    try:
-        with urllib.request.urlopen(url, timeout=timeout) as resp:
-            status = getattr(resp, "status", 200)
-            if status != 200:
-                _warn(f"arxiv lookup HTTP {status} for {arxiv_id}")
-                return None
-            data = resp.read()
-    except Exception as e:  # noqa: BLE001
-        _warn(f"arxiv lookup failed for {arxiv_id}: {e}")
+    body, _headers, err = safe_fetch(url)
+    if err:
+        _warn(f"arxiv lookup blocked or failed: {err}")
         return None
+    if body is None:
+        return None
+    data = body
 
     try:
         root = _xml_fromstring(data)

--- a/any2md/utils.py
+++ b/any2md/utils.py
@@ -51,6 +51,20 @@ def read_text_with_fallback(path: Path) -> str:
         return path.read_text(encoding="latin-1")
 
 
+def safe_dir_name(name: str) -> str:
+    """Conservative directory-name sanitizer: alphanumeric/_/- only.
+
+    Used for output sub-directories whose name comes from an untrusted
+    input filename stem. Replaces every non-allowed char with ``_``,
+    collapses runs of ``_``, strips leading/trailing ``_``, and falls
+    back to ``"untitled"`` for empty results.
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9_-]", "_", name)
+    cleaned = _COLLAPSE_UNDERSCORES_RE.sub("_", cleaned)
+    cleaned = cleaned.strip("_") or "untitled"
+    return cleaned
+
+
 def url_to_filename(url: str) -> str:
     """Convert a URL to a sanitized .md filename.
 

--- a/any2md/utils.py
+++ b/any2md/utils.py
@@ -6,7 +6,9 @@ modules (any2md/frontmatter.py, any2md/pipeline/cleanup.py).
 
 from __future__ import annotations
 
+import os
 import re
+import tempfile
 import urllib.parse
 from pathlib import Path
 
@@ -41,6 +43,34 @@ def strip_links(text: str) -> str:
     (removed in Phase 4 once gating moves to the pipeline).
     """
     return _LINK_RE.sub(r"\1", text)
+
+
+def atomic_write_text(out_path: Path, content: str) -> None:
+    """Write text atomically; refuse to clobber a symlink target.
+
+    Creates a sibling temp file in ``out_path``'s parent dir, fsyncs,
+    then ``os.replace``s it over ``out_path``. If ``out_path`` is a
+    pre-existing symlink, raises ``ValueError`` rather than overwriting
+    whatever the link points to. Defends against symlink-redirect
+    attacks at the output path and partial-write windows for concurrent
+    readers.
+    """
+    if out_path.is_symlink():
+        raise ValueError(f"refusing to write through symlink: {out_path}")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=".any2md-", suffix=".tmp", dir=out_path.parent
+    )
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, out_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
 
 
 def read_text_with_fallback(path: Path) -> str:

--- a/docs/superpowers/plans/2026-04-27-v1.0.6-security-hardening.md
+++ b/docs/superpowers/plans/2026-04-27-v1.0.6-security-hardening.md
@@ -1,0 +1,1867 @@
+# v1.0.6 Security Hardening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Close all 8 actionable findings from the 2026-04-27 security audit + bump CVE-affected transitive deps + adopt defusedxml for XXE defense-in-depth, shipped as v1.0.6 patch release.
+
+**Architecture:** New `any2md/_http.py` module centralizes URL validation and SSRF-safe fetching with manual redirect walking and per-hop revalidation. Reserved-key filter, TOML walk-up boundary, DOCX zip-bomb guard, atomic-write helper, and small sanitizers added incrementally. Each fix lands as its own atomic commit on `feat/v1.0.6-security-hardening` (already created).
+
+**Tech Stack:** Python 3.10+, `urllib.request`, `defusedxml`, `tempfile`, `pytest`, `ruff`, `bandit`.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-v1.0.6-security-hardening-design.md` (commit `3e99a54`).
+
+**Pre-flight (do once before Task 1):**
+```bash
+cd /Users/klambros/github_projects/any2md
+git status -sb               # expect: ## feat/v1.0.6-security-hardening
+git log --oneline -1         # expect: 3e99a54 docs(spec): v1.0.6 security hardening design
+python -m pytest tests/ -q   # expect: 290 passed, 1 skipped (baseline)
+```
+
+---
+
+## Task 1: Bump version + dep floors + add defusedxml + lockfile pins
+
+**Files:**
+- Modify: `any2md/__init__.py` (version bump)
+- Modify: `pyproject.toml` (dependency ranges)
+- Modify: `requirements.txt` (exact pins for dev/CI lockfile)
+
+This task is mechanical — no new tests; CI's smoke and existing test suite are the gate.
+
+- [ ] **Step 1: Bump `__version__`**
+
+```python
+# any2md/__init__.py
+"""Convert PDF, DOCX, HTML, and TXT files to LLM-optimized Markdown."""
+
+__version__ = "1.0.6"
+```
+
+- [ ] **Step 2: Update `pyproject.toml` dependencies block**
+
+Replace the existing `dependencies = [...]` block with:
+
+```toml
+dependencies = [
+    "pymupdf>=1.24.0,<2",
+    "pymupdf4llm>=0.0.17,<1",
+    "mammoth>=1.6.0,<2",
+    "markdownify>=0.13.0,<2",
+    "trafilatura>=1.12.0,<3",
+    "beautifulsoup4>=4.12.0,<5",
+    "lxml>=6.1.0,<7",        # CVE-2026-41066 fix
+    "pillow>=12.2.0,<13",    # CVE-2026-25990, CVE-2026-40192 fix
+    "urllib3>=2.6.3,<3",     # CVE-2026-21441 fix
+    "defusedxml>=0.7.1,<1",  # XXE defense-in-depth (Task 2)
+]
+```
+
+- [ ] **Step 3: Update `requirements.txt` to exact pins**
+
+Replace the existing content with the lockfile pins (use the latest patches available on PyPI as of run time; the floors below are the minimum):
+
+```
+pymupdf==1.24.14
+pymupdf4llm==0.0.17
+mammoth==1.8.0
+markdownify==0.13.1
+trafilatura==2.0.0
+beautifulsoup4==4.13.5
+lxml==6.1.0
+pillow==12.2.0
+urllib3==2.6.3
+defusedxml==0.7.1
+```
+
+(If `pip index versions <pkg>` shows a newer patch on each line's major.minor, prefer the newer patch.)
+
+- [ ] **Step 4: Reinstall and run baseline test suite**
+
+Run:
+```bash
+pip install -e . --quiet --upgrade && python -m pytest tests/ -q
+```
+
+Expected: `290 passed, 1 skipped`. If `defusedxml` isn't found, the `pip install` line installs it via the new dep. If lxml/pillow/urllib3 upgrade fails for transitive reasons, drop the upper bounds (keep the floors) and retry.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add any2md/__init__.py pyproject.toml requirements.txt
+git commit -m "$(cat <<'EOF'
+chore(deps): bump version + tighten ranges + add defusedxml (v1.0.6)
+
+- Version 1.0.5 -> 1.0.6 (security hardening patch)
+- lxml>=6.1.0,<7 fixes CVE-2026-41066
+- pillow>=12.2.0,<13 fixes CVE-2026-25990, CVE-2026-40192
+- urllib3>=2.6.3,<3 fixes CVE-2026-21441
+- defusedxml>=0.7.1,<1 added for XXE defense-in-depth (Task 2)
+- requirements.txt becomes a dev/CI lockfile with exact pins
+EOF
+)"
+```
+
+---
+
+## Task 2: Migrate XML parsing to defusedxml
+
+**Files:**
+- Modify: `any2md/converters/docx.py` (replace `xml.etree.ElementTree` import + ET.parse calls)
+- Modify: `any2md/heuristics.py` (replace `xml.etree.ElementTree` import + ET.fromstring calls inside `arxiv_lookup`)
+
+Mechanical refactor; existing tests are the verification.
+
+- [ ] **Step 1: Verify existing tests pass before change**
+
+Run:
+```bash
+python -m pytest tests/integration/test_docx_docling.py tests/integration/test_docx_mammoth_fallback.py tests/unit/test_heuristics.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 2: Update `any2md/converters/docx.py` import + parse sites**
+
+Replace `import xml.etree.ElementTree as ET` (around line 13) with:
+```python
+from defusedxml.ElementTree import parse as _xml_parse
+```
+
+Then in `_read_docx_metadata`, replace BOTH `ET.parse(f).getroot()` calls (one for `core.xml`, one for `app.xml`) with `_xml_parse(f).getroot()`.
+
+Replace `except (zipfile.BadZipFile, ET.ParseError):` with:
+```python
+from defusedxml.ElementTree import ParseError as _XmlParseError
+...
+except (zipfile.BadZipFile, _XmlParseError):
+```
+
+(Or import both at top: `from defusedxml.ElementTree import parse as _xml_parse, ParseError as _XmlParseError`.)
+
+- [ ] **Step 3: Update `any2md/heuristics.py` arxiv-lookup XML parse**
+
+Inside `arxiv_lookup` (around line 533), replace:
+```python
+import xml.etree.ElementTree as ET
+```
+with:
+```python
+from defusedxml.ElementTree import fromstring as _xml_fromstring, ParseError as _XmlParseError
+```
+
+Replace `root = ET.fromstring(data)` with `root = _xml_fromstring(data)`. Replace `except ET.ParseError as e:` with `except _XmlParseError as e:`.
+
+- [ ] **Step 4: Run targeted tests**
+
+```bash
+python -m pytest tests/integration/test_docx_docling.py tests/integration/test_docx_mammoth_fallback.py tests/unit/test_heuristics.py -q
+```
+
+Expected: same green count as Step 1 (no regressions).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add any2md/converters/docx.py any2md/heuristics.py
+git commit -m "$(cat <<'EOF'
+security: migrate XML parsing to defusedxml (XXE defense-in-depth)
+
+stdlib `xml.etree.ElementTree` already disables DTD/external entities
+in Python 3.7+, so no exploitable XXE existed. Migration to defusedxml
+is belt-and-suspenders coverage and silences bandit B405/B314.
+
+- any2md/converters/docx.py: ET.parse -> defusedxml.ElementTree.parse
+- any2md/heuristics.py:      ET.fromstring -> defusedxml fromstring
+EOF
+)"
+```
+
+---
+
+## Task 3: Create `any2md/_http.py` (validate_url + safe_fetch)
+
+**Files:**
+- Create: `any2md/_http.py`
+- Test: `tests/unit/test_http_safe.py`
+
+Pure-module + tests; consumers wired in Tasks 4 and 5.
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_http_safe.py`:
+```python
+"""Unit tests for any2md._http (URL validation + SSRF-safe fetcher).
+
+Tests use socket.getaddrinfo monkeypatching so they don't require DNS
+or network access.
+"""
+
+from __future__ import annotations
+
+import io
+import socket
+import urllib.error
+from email.message import Message
+from typing import Iterable
+
+import pytest
+
+from any2md._http import (
+    _MAX_REDIRECT_HOPS,
+    _MAX_RESPONSE_BYTES,
+    safe_fetch,
+    validate_url,
+)
+
+
+def _stub_dns(monkeypatch, mapping: dict[str, str]) -> None:
+    """Make socket.getaddrinfo return mapping[host] for any lookup."""
+
+    def fake(host, *args, **kwargs):
+        ip = mapping.get(host, "1.1.1.1")  # default: a public IP
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0))]
+
+    monkeypatch.setattr("any2md._http.socket.getaddrinfo", fake)
+
+
+# ---------- validate_url ----------
+
+
+@pytest.mark.parametrize(
+    "ip,expect_disallowed",
+    [
+        ("127.0.0.1", True),
+        ("10.0.0.1", True),
+        ("192.168.1.1", True),
+        ("169.254.169.254", True),  # AWS metadata
+        ("::1", True),
+        ("8.8.8.8", False),
+        ("1.1.1.1", False),
+    ],
+)
+def test_validate_url_ip_classification(monkeypatch, ip, expect_disallowed):
+    _stub_dns(monkeypatch, {"x.example": ip})
+    err = validate_url("https://x.example/")
+    if expect_disallowed:
+        assert err is not None and "disallowed" in err
+    else:
+        assert err is None
+
+
+def test_validate_url_rejects_non_http_scheme(monkeypatch):
+    err = validate_url("ftp://example.com/")
+    assert err and "scheme" in err
+
+
+def test_validate_url_rejects_file_scheme(monkeypatch):
+    err = validate_url("file:///etc/passwd")
+    assert err and "scheme" in err
+
+
+def test_validate_url_no_hostname(monkeypatch):
+    err = validate_url("http:///path-only")
+    assert err and "hostname" in err
+
+
+def test_validate_url_unresolvable(monkeypatch):
+    def boom(*_a, **_kw):
+        raise socket.gaierror("nodename nor servname provided")
+
+    monkeypatch.setattr("any2md._http.socket.getaddrinfo", boom)
+    err = validate_url("https://does-not-exist.invalid/")
+    assert err and "resolve" in err
+
+
+# ---------- safe_fetch redirect walking ----------
+
+
+class _FakeHTTPResponse:
+    def __init__(self, body: bytes, headers: dict[str, str] | None = None):
+        self._body = body
+        self._buf = io.BytesIO(body)
+        msg = Message()
+        for k, v in (headers or {}).items():
+            msg[k] = v
+        self.headers = msg
+
+    def read(self, n: int | None = None) -> bytes:
+        return self._buf.read(n) if n is not None else self._buf.read()
+
+
+def _http_error(code: int, location: str | None = None) -> urllib.error.HTTPError:
+    msg = Message()
+    if location:
+        msg["Location"] = location
+    return urllib.error.HTTPError(
+        url="x", code=code, msg="redirect", hdrs=msg, fp=None
+    )
+
+
+class _FakeOpener:
+    def __init__(self, responses: Iterable):
+        self.responses = list(responses)
+        self.calls: list[str] = []
+
+    def open(self, req, timeout):
+        self.calls.append(req.full_url)
+        r = self.responses.pop(0)
+        if isinstance(r, urllib.error.HTTPError):
+            raise r
+        return r
+
+
+def _patch_opener(monkeypatch, opener: _FakeOpener) -> None:
+    monkeypatch.setattr(
+        "any2md._http.urllib.request.build_opener", lambda *_: opener
+    )
+
+
+def test_safe_fetch_simple_200(monkeypatch):
+    _stub_dns(monkeypatch, {"public.example": "1.1.1.1"})
+    opener = _FakeOpener([_FakeHTTPResponse(b"<html>ok</html>", {"X-Test": "1"})])
+    _patch_opener(monkeypatch, opener)
+    body, headers, err = safe_fetch("https://public.example/")
+    assert err is None
+    assert body == b"<html>ok</html>"
+    assert headers and headers.get("X-Test") == "1"
+    assert opener.calls == ["https://public.example/"]
+
+
+def test_safe_fetch_follows_redirect_within_limit(monkeypatch):
+    _stub_dns(monkeypatch, {"a.example": "1.1.1.1", "b.example": "2.2.2.2"})
+    opener = _FakeOpener(
+        [
+            _http_error(302, "https://b.example/"),
+            _FakeHTTPResponse(b"final"),
+        ]
+    )
+    _patch_opener(monkeypatch, opener)
+    body, _h, err = safe_fetch("https://a.example/")
+    assert err is None
+    assert body == b"final"
+    assert opener.calls == ["https://a.example/", "https://b.example/"]
+
+
+def test_safe_fetch_rejects_redirect_to_private(monkeypatch):
+    _stub_dns(
+        monkeypatch,
+        {"a.example": "1.1.1.1", "rebound.example": "169.254.169.254"},
+    )
+    opener = _FakeOpener([_http_error(302, "https://rebound.example/")])
+    _patch_opener(monkeypatch, opener)
+    body, _h, err = safe_fetch("https://a.example/")
+    assert body is None
+    assert err and "disallowed" in err
+
+
+def test_safe_fetch_max_hops(monkeypatch):
+    _stub_dns(monkeypatch, {f"h{i}.example": "1.1.1.1" for i in range(10)})
+    chain = [
+        _http_error(302, f"https://h{i+1}.example/")
+        for i in range(_MAX_REDIRECT_HOPS + 2)
+    ]
+    opener = _FakeOpener(chain)
+    _patch_opener(monkeypatch, opener)
+    _b, _h, err = safe_fetch("https://h0.example/")
+    assert err and "too many redirects" in err.lower()
+
+
+def test_safe_fetch_loop_detection(monkeypatch):
+    _stub_dns(monkeypatch, {"loop.example": "1.1.1.1"})
+    opener = _FakeOpener([_http_error(302, "https://loop.example/")])
+    _patch_opener(monkeypatch, opener)
+    _b, _h, err = safe_fetch("https://loop.example/")
+    assert err and "loop" in err.lower()
+
+
+def test_safe_fetch_response_size_cap(monkeypatch):
+    _stub_dns(monkeypatch, {"big.example": "1.1.1.1"})
+    huge = b"x" * (_MAX_RESPONSE_BYTES + 100)
+    opener = _FakeOpener([_FakeHTTPResponse(huge)])
+    _patch_opener(monkeypatch, opener)
+    _b, _h, err = safe_fetch("https://big.example/")
+    assert err and "exceeds" in err
+
+
+def test_safe_fetch_head_method(monkeypatch):
+    _stub_dns(monkeypatch, {"head.example": "1.1.1.1"})
+    opener = _FakeOpener(
+        [_FakeHTTPResponse(b"", {"Last-Modified": "Wed, 01 Jan 2025 00:00:00 GMT"})]
+    )
+    _patch_opener(monkeypatch, opener)
+    _b, headers, err = safe_fetch("https://head.example/", method="HEAD")
+    assert err is None
+    assert headers and headers.get("Last-Modified")
+
+
+def test_safe_fetch_http_error_other(monkeypatch):
+    _stub_dns(monkeypatch, {"err.example": "1.1.1.1"})
+    opener = _FakeOpener([_http_error(500)])
+    _patch_opener(monkeypatch, opener)
+    _b, _h, err = safe_fetch("https://err.example/")
+    assert err and "500" in err
+```
+
+- [ ] **Step 2: Run tests, expect failures**
+
+Run:
+```bash
+python -m pytest tests/unit/test_http_safe.py -v 2>&1 | tail -20
+```
+
+Expected: `ImportError: cannot import name 'safe_fetch' from 'any2md._http'` (or module-not-found).
+
+- [ ] **Step 3: Implement `any2md/_http.py`**
+
+Create:
+```python
+"""SSRF-safe HTTP fetching utilities for any2md.
+
+Centralizes URL scheme + IP validation and provides a fetcher that
+walks redirects manually and revalidates the host on each hop. This
+defends against:
+  - DNS rebinding (host → public IP for validator, private IP for fetch)
+  - Redirect-based SSRF (public landing page → 302 to 169.254.169.254)
+  - Non-http(s) schemes (file://, gopher://, etc.)
+  - Decompression / huge-response DoS (response-size cap)
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+import urllib.error
+import urllib.parse
+import urllib.request
+
+_MAX_REDIRECT_HOPS = 3
+_FETCH_TIMEOUT = 15  # seconds
+_MAX_RESPONSE_BYTES = 20 * 1024 * 1024  # 20 MB cap on body read
+_USER_AGENT = "any2md/1.0.6"
+
+
+def validate_url(url: str) -> str | None:
+    """Validate URL scheme + host. Returns an error message or None.
+
+    One-shot DNS lookup; rebind protection requires re-checking on
+    every redirect hop (handled by ``safe_fetch``).
+    """
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return f"unsupported scheme: {parsed.scheme!r}"
+    if not parsed.hostname:
+        return f"no hostname in URL: {url}"
+    try:
+        infos = socket.getaddrinfo(
+            parsed.hostname, None, type=socket.SOCK_STREAM
+        )
+    except socket.gaierror:
+        return f"cannot resolve host: {parsed.hostname}"
+    for *_, sockaddr in infos:
+        try:
+            addr = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            continue
+        if (
+            addr.is_private
+            or addr.is_reserved
+            or addr.is_loopback
+            or addr.is_link_local
+        ):
+            return f"URL resolves to disallowed address: {addr}"
+    return None
+
+
+class _NoFollowRedirect(urllib.request.HTTPRedirectHandler):
+    """Disable urllib's automatic redirect following."""
+
+    def redirect_request(self, *args, **kwargs):  # noqa: ARG002
+        return None
+
+
+def safe_fetch(
+    url: str,
+    *,
+    method: str = "GET",
+    max_hops: int = _MAX_REDIRECT_HOPS,
+) -> tuple[bytes | None, dict | None, str | None]:
+    """Fetch ``url`` with manual redirect walking + per-hop revalidation.
+
+    Returns ``(body, headers, None)`` on 2xx, or ``(None, None, error)``
+    on rejection / failure. ``headers`` is the response headers as a
+    plain ``dict`` (case-insensitive keys preserved by the caller).
+    """
+    visited: list[str] = []
+    current = url
+    opener = urllib.request.build_opener(_NoFollowRedirect())
+    for hop in range(max_hops + 1):
+        if current in visited:
+            return None, None, "redirect loop"
+        visited.append(current)
+        err = validate_url(current)
+        if err:
+            return None, None, err
+        req = urllib.request.Request(
+            current, method=method, headers={"User-Agent": _USER_AGENT}
+        )
+        try:
+            resp = opener.open(req, timeout=_FETCH_TIMEOUT)
+        except urllib.error.HTTPError as e:
+            if e.code in (301, 302, 303, 307, 308) and hop < max_hops:
+                location = e.headers.get("Location") if e.headers else None
+                if not location:
+                    return None, None, f"HTTP {e.code} without Location"
+                current = urllib.parse.urljoin(current, location)
+                continue
+            return None, None, f"HTTP {e.code}"
+        except (urllib.error.URLError, OSError, TimeoutError) as e:
+            return None, None, f"fetch error: {e}"
+        body = resp.read(_MAX_RESPONSE_BYTES + 1)
+        if len(body) > _MAX_RESPONSE_BYTES:
+            return None, None, f"response exceeds {_MAX_RESPONSE_BYTES} bytes"
+        return body, dict(resp.headers), None
+    return None, None, f"too many redirects (>{max_hops})"
+```
+
+- [ ] **Step 4: Run tests, expect green**
+
+Run:
+```bash
+python -m pytest tests/unit/test_http_safe.py -v 2>&1 | tail -20
+```
+
+Expected: all tests pass (≈12 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add any2md/_http.py tests/unit/test_http_safe.py
+git commit -m "$(cat <<'EOF'
+security(F1): add _http.py with validate_url + safe_fetch
+
+Centralizes SSRF defenses for any2md:
+- validate_url: scheme + IP-class check (rejects private/loopback/
+  link-local/reserved); single DNS lookup
+- safe_fetch: manual redirect walking with per-hop revalidation
+  (defends DNS rebind via redirects), max 3 hops, 20 MB body cap,
+  custom _NoFollowRedirect handler disables urllib auto-follow
+
+12 unit tests covering IP-class boundaries, scheme rejection,
+redirect-rebind blocking, max-hops, loop detection, size cap.
+
+Consumers wired in Tasks 4-5.
+EOF
+)"
+```
+
+---
+
+## Task 4: Wire `any2md/converters/html.py` to `_http`
+
+**Files:**
+- Modify: `any2md/converters/html.py` (replace `_validate_url_host`, `fetch_url`, `_http_last_modified`; pass body to `trafilatura.extract`)
+- Test: `tests/integration/test_html_trafilatura.py` (add SSRF rejection cases — file may exist; check first)
+
+- [ ] **Step 1: Write/extend failing tests**
+
+Check whether `tests/integration/test_html_trafilatura.py` exists:
+```bash
+ls tests/integration/test_html_trafilatura.py
+```
+
+Append (or create with these contents):
+```python
+"""SSRF / fetcher integration tests for html.py."""
+
+from __future__ import annotations
+
+import socket
+import urllib.error
+from email.message import Message
+from io import BytesIO
+
+import pytest
+
+import any2md.converters.html as html_mod
+
+
+class _FakeResp:
+    def __init__(self, body: bytes, headers: dict[str, str] | None = None):
+        self._buf = BytesIO(body)
+        m = Message()
+        for k, v in (headers or {}).items():
+            m[k] = v
+        self.headers = m
+
+    def read(self, n: int | None = None) -> bytes:
+        return self._buf.read(n) if n is not None else self._buf.read()
+
+
+def _http_err(code: int, location: str | None = None):
+    m = Message()
+    if location:
+        m["Location"] = location
+    return urllib.error.HTTPError("x", code, "redir", m, None)
+
+
+class _FakeOpener:
+    def __init__(self, seq):
+        self.seq = list(seq)
+        self.calls = []
+
+    def open(self, req, timeout):
+        self.calls.append(req.full_url)
+        r = self.seq.pop(0)
+        if isinstance(r, urllib.error.HTTPError):
+            raise r
+        return r
+
+
+def _stub_dns(monkeypatch, mapping):
+    def fake(host, *_a, **_kw):
+        ip = mapping.get(host, "1.1.1.1")
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0))]
+
+    monkeypatch.setattr("any2md._http.socket.getaddrinfo", fake)
+
+
+def _patch_opener(monkeypatch, opener):
+    monkeypatch.setattr(
+        "any2md._http.urllib.request.build_opener", lambda *_: opener
+    )
+
+
+def test_fetch_url_rejects_redirect_to_metadata_endpoint(monkeypatch):
+    _stub_dns(
+        monkeypatch,
+        {"public.example": "1.1.1.1", "rebound.example": "169.254.169.254"},
+    )
+    opener = _FakeOpener([_http_err(302, "http://rebound.example/")])
+    _patch_opener(monkeypatch, opener)
+    body, err = html_mod.fetch_url("https://public.example/")
+    assert body is None
+    assert err and "disallowed" in err
+
+
+def test_fetch_url_rejects_file_scheme(monkeypatch):
+    body, err = html_mod.fetch_url("file:///etc/passwd")
+    assert body is None
+    assert err and "scheme" in err
+
+
+def test_http_last_modified_validates_host(monkeypatch):
+    _stub_dns(monkeypatch, {"meta.example": "169.254.169.254"})
+    # No opener patch: validate_url should reject before any fetch
+    assert html_mod._http_last_modified("http://meta.example/") is None
+```
+
+- [ ] **Step 2: Run tests, expect failures**
+
+```bash
+python -m pytest tests/integration/test_html_trafilatura.py -v 2>&1 | tail -15
+```
+
+Expected: failures because the production code still uses `trafilatura.fetch_url` which doesn't honor our mocks.
+
+- [ ] **Step 3: Update `any2md/converters/html.py`**
+
+Replace the existing `_validate_url_host`, `fetch_url`, and `_http_last_modified` functions. The full updated header section becomes:
+
+```python
+"""HTML to Markdown converter (v1.0)."""
+
+from __future__ import annotations
+
+import sys
+import urllib.parse
+from datetime import date
+from email.utils import parsedate_to_datetime
+from pathlib import Path
+
+import markdownify
+import trafilatura
+from bs4 import BeautifulSoup
+
+from any2md import pipeline
+from any2md._http import safe_fetch, validate_url
+from any2md.converters import add_warnings, is_quiet
+from any2md.frontmatter import SourceMeta, compose
+from any2md.pipeline import PipelineOptions
+from any2md.utils import (
+    read_text_with_fallback,
+    sanitize_filename,
+    url_to_filename,
+)
+
+
+def fetch_url(url: str) -> tuple[str | None, str | None]:
+    """Fetch HTML from a URL using the SSRF-safe fetcher.
+
+    Returns (html_string, None) on success or (None, error_message) on failure.
+    Per-hop host revalidation defends against DNS rebind via redirects.
+    """
+    body, _headers, err = safe_fetch(url)
+    if err:
+        return None, err
+    if body is None:
+        return None, f"empty body for {url}"
+    return body.decode("utf-8", errors="replace"), None
+
+
+def _http_last_modified(url: str) -> str | None:
+    """Single HEAD request for Last-Modified. Best-effort.
+
+    SSRF-safe: same scheme + IP validation as fetch_url.
+    """
+    _body, headers, err = safe_fetch(url, method="HEAD")
+    if err or not headers:
+        return None
+    lm = headers.get("Last-Modified")
+    if not lm:
+        return None
+    try:
+        return parsedate_to_datetime(lm).date().isoformat()
+    except (TypeError, ValueError):
+        return None
+```
+
+The unused imports (`ipaddress`, `socket`, `urllib.request`) should be deleted from the top of the file. The `_MAX_FILE_SIZE` constant near the top is unused (verify with grep) and can be removed.
+
+- [ ] **Step 4: Run targeted tests + full suite**
+
+```bash
+python -m pytest tests/integration/test_html_trafilatura.py tests/unit/test_http_safe.py -v 2>&1 | tail -20
+python -m pytest tests/ -q 2>&1 | tail -3
+```
+
+Expected: SSRF tests pass; full suite green (290+ tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add any2md/converters/html.py tests/integration/test_html_trafilatura.py
+git commit -m "$(cat <<'EOF'
+security(F1): wire html.py to _http.safe_fetch
+
+- fetch_url now uses safe_fetch (manual redirect walk, per-hop revalidate)
+- _http_last_modified now also goes through safe_fetch for HEAD;
+  previously had no scheme/IP check at all
+- removed local _validate_url_host (moved to any2md/_http.validate_url)
+- 3 new SSRF integration tests cover redirect-to-metadata,
+  file:// scheme, and HEAD-path validation
+EOF
+)"
+```
+
+---
+
+## Task 5: Wire arxiv lookup to `_http.safe_fetch`
+
+**Files:**
+- Modify: `any2md/heuristics.py` (`arxiv_lookup` function)
+- Test: `tests/unit/test_heuristics.py` (add SSRF rejection case for arxiv)
+
+- [ ] **Step 1: Write failing test**
+
+Append to `tests/unit/test_heuristics.py`:
+```python
+def test_arxiv_lookup_rejects_dns_rebind(monkeypatch):
+    """If export.arxiv.org somehow resolves to a private IP, lookup is blocked."""
+    import socket as _s
+
+    def fake_resolve(host, *_a, **_kw):
+        return [(_s.AF_INET, _s.SOCK_STREAM, 0, "", ("169.254.169.254", 0))]
+
+    monkeypatch.setattr("any2md._http.socket.getaddrinfo", fake_resolve)
+    from any2md.heuristics import arxiv_lookup
+    result = arxiv_lookup("2401.00001")
+    assert result is None  # SSRF guard rejected the fetch
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+```bash
+python -m pytest tests/unit/test_heuristics.py::test_arxiv_lookup_rejects_dns_rebind -v 2>&1 | tail -10
+```
+
+Expected: failure (the existing arxiv_lookup uses `urllib.request.urlopen` directly with no rebind protection on the fetched IP).
+
+- [ ] **Step 3: Update `arxiv_lookup` to use `safe_fetch`**
+
+In `any2md/heuristics.py` `arxiv_lookup` function (around line 533), replace the SSRF guard + urlopen block with a single `safe_fetch` call:
+
+```python
+    # SSRF guard + fetch via shared _http helper
+    try:
+        from any2md._http import safe_fetch
+    except Exception as e:  # noqa: BLE001
+        _warn(f"arxiv lookup _http import failed: {e}")
+        return None
+
+    body, _headers, err = safe_fetch(url)
+    if err:
+        _warn(f"arxiv lookup blocked or failed: {err}")
+        return None
+    if body is None:
+        return None
+    data = body
+```
+
+Replace any remaining direct `urllib.request.urlopen` and `_validate_url_host` references in this function. Keep the existing `try/except (Exception): pass` patterns inside `_warn`.
+
+- [ ] **Step 4: Run tests**
+
+```bash
+python -m pytest tests/unit/test_heuristics.py -q 2>&1 | tail -5
+```
+
+Expected: all heuristics tests pass, including the new SSRF guard test.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add any2md/heuristics.py tests/unit/test_heuristics.py
+git commit -m "$(cat <<'EOF'
+security(F1): route arxiv lookup through _http.safe_fetch
+
+Removes the direct urllib.request.urlopen call and the lazy import of
+the now-removed _validate_url_host. arxiv_lookup gets the same
+manual-redirect-walk + per-hop revalidation as html.py callers.
+EOF
+)"
+```
+
+---
+
+## Task 6: Reserved-key filter for `--meta` overrides (F5)
+
+**Files:**
+- Modify: `any2md/frontmatter.py` (add `_RESERVED_OVERRIDE_KEYS` + `filter_reserved_overrides`)
+- Modify: `any2md/cli.py` (call filter once after merge)
+- Test: `tests/unit/test_meta_reserved_keys.py` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_meta_reserved_keys.py`:
+```python
+"""Tests for filter_reserved_overrides (F5: --meta integrity)."""
+
+from __future__ import annotations
+
+import pytest
+
+from any2md.frontmatter import _RESERVED_OVERRIDE_KEYS, filter_reserved_overrides
+
+
+@pytest.mark.parametrize(
+    "key",
+    sorted(_RESERVED_OVERRIDE_KEYS),
+)
+def test_each_reserved_key_dropped_with_warn(capsys, key):
+    out = filter_reserved_overrides({key: "x", "title": "ok"})
+    assert key not in out
+    assert out["title"] == "ok"
+    err = capsys.readouterr().err
+    assert key in err and "reserved" in err.lower()
+
+
+def test_non_reserved_keys_preserved(capsys):
+    overrides = {"title": "T", "authors": ["a"], "organization": "o"}
+    out = filter_reserved_overrides(overrides)
+    assert out == overrides
+    assert capsys.readouterr().err == ""
+
+
+def test_nested_dict_under_non_reserved_untouched():
+    overrides = {"generation_metadata": {"authored_by": "human"}}
+    out = filter_reserved_overrides(overrides)
+    assert out == overrides
+
+
+def test_none_passes_through():
+    assert filter_reserved_overrides(None) is None
+
+
+def test_empty_dict_passes_through():
+    assert filter_reserved_overrides({}) == {}
+```
+
+- [ ] **Step 2: Run tests, expect failures (ImportError)**
+
+```bash
+python -m pytest tests/unit/test_meta_reserved_keys.py -v 2>&1 | tail -10
+```
+
+Expected: `ImportError: cannot import name '_RESERVED_OVERRIDE_KEYS' or 'filter_reserved_overrides'`.
+
+- [ ] **Step 3: Implement filter in `frontmatter.py`**
+
+Near the top of `any2md/frontmatter.py` (after existing imports), add:
+```python
+import sys
+from typing import Mapping
+
+_RESERVED_OVERRIDE_KEYS = frozenset(
+    {
+        "content_hash",
+        "token_estimate",
+        "recommended_chunk_level",
+        "extracted_via",
+        "source_file",
+        "lane",
+    }
+)
+
+
+def filter_reserved_overrides(
+    overrides: Mapping[str, object] | None,
+    *,
+    source_label: str = "overrides",
+) -> dict[str, object] | None:
+    """Drop top-level reserved keys; emit stderr WARN per drop.
+
+    Reserved keys are derived from the source document and must not be
+    overridable via ``--meta``, ``--meta-file``, or ``.any2md.toml``.
+    Nested dicts under non-reserved keys are returned untouched.
+    """
+    if overrides is None:
+        return None
+    out: dict[str, object] = {}
+    for k, v in overrides.items():
+        if k in _RESERVED_OVERRIDE_KEYS:
+            print(
+                f"  WARN: ignoring {source_label} key {k!r} "
+                f"— reserved (derived from source).",
+                file=sys.stderr,
+            )
+            continue
+        out[k] = v
+    return out
+```
+
+- [ ] **Step 4: Wire into `any2md/cli.py`**
+
+In `cli.py` `main()` function, immediately after the existing `overrides = _deep_merge_overrides(overrides, cli_meta)` line, add:
+```python
+from any2md.frontmatter import filter_reserved_overrides
+overrides = filter_reserved_overrides(
+    overrides, source_label="--meta/--meta-file/.any2md.toml"
+)
+```
+
+(Place the import at the top of the file with the other imports for cleanliness.)
+
+Also in `frontmatter.compose` (defense-in-depth), add at the top of the function (before merge logic):
+```python
+overrides = filter_reserved_overrides(overrides, source_label="compose()")
+```
+
+- [ ] **Step 5: Run tests + commit**
+
+```bash
+python -m pytest tests/unit/test_meta_reserved_keys.py tests/ -q 2>&1 | tail -5
+```
+
+Expected: 295+ passed (adds ~10 new tests).
+
+```bash
+git add any2md/frontmatter.py any2md/cli.py tests/unit/test_meta_reserved_keys.py
+git commit -m "$(cat <<'EOF'
+security(F5): silently filter reserved --meta keys with stderr warning
+
+User-supplied --meta / --meta-file / .any2md.toml overrides can no
+longer clobber derived frontmatter fields (content_hash, extracted_via,
+source_file, lane, token_estimate, recommended_chunk_level). Each
+attempt is dropped with a stderr WARN line; conversion proceeds with
+the derived value. Defense-in-depth: filter is also applied inside
+frontmatter.compose so non-CLI callers are protected.
+EOF
+)"
+```
+
+---
+
+## Task 7: TOML walk-up boundary + `--no-config` flag (F3)
+
+**Files:**
+- Modify: `any2md/config.py` (`discover_config` + module-level `_PROJECT_BOUNDARY_MARKERS`)
+- Modify: `any2md/cli.py` (new `--no-config` flag, gate `discover_config()`)
+- Test: `tests/unit/test_config_walkup.py` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_config_walkup.py`:
+```python
+"""Tests for discover_config boundary behavior (F3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from any2md.config import discover_config
+
+
+def test_stops_at_git_root(tmp_path):
+    # /tmp_path/repo/.git, /tmp_path/repo/sub/, .any2md.toml above repo
+    (tmp_path / ".any2md.toml").write_text("[meta]\n", encoding="utf-8")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    sub = repo / "sub"
+    sub.mkdir()
+    assert discover_config(start=sub) is None
+
+
+def test_stops_at_pyproject_toml(tmp_path):
+    (tmp_path / ".any2md.toml").write_text("[meta]\n", encoding="utf-8")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    sub = repo / "sub"
+    sub.mkdir()
+    assert discover_config(start=sub) is None
+
+
+def test_finds_config_inside_project(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / ".any2md.toml").write_text("[meta]\n", encoding="utf-8")
+    sub = repo / "sub"
+    sub.mkdir()
+    found = discover_config(start=sub)
+    assert found == (repo / ".any2md.toml").resolve()
+
+
+def test_returns_none_when_no_config(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").touch()
+    assert discover_config(start=repo) is None
+
+
+def test_honors_explicit_boundary_marker(tmp_path):
+    (tmp_path / ".any2md.toml").write_text("[meta]\n", encoding="utf-8")
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    (inner / ".any2md.toml.boundary").touch()
+    sub = inner / "sub"
+    sub.mkdir()
+    assert discover_config(start=sub) is None
+```
+
+- [ ] **Step 2: Run tests, expect failures (some pass — current behavior just walks to root, so test for boundary will fail)**
+
+```bash
+python -m pytest tests/unit/test_config_walkup.py -v 2>&1 | tail -15
+```
+
+Expected: `test_stops_at_git_root`, `test_stops_at_pyproject_toml`, `test_honors_explicit_boundary_marker` fail (current code walks past these markers).
+
+- [ ] **Step 3: Update `any2md/config.py`**
+
+Add module-level constant near the top:
+```python
+_PROJECT_BOUNDARY_MARKERS = (
+    ".git",
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "package.json",
+    ".any2md.toml.boundary",
+)
+```
+
+Modify `discover_config`:
+```python
+def discover_config(start: Path | None = None) -> Path | None:
+    """Walk up from ``start`` (cwd if None) looking for ``.any2md.toml``.
+
+    Stops at the first ancestor containing a project boundary marker
+    (``.git``, ``pyproject.toml``, ``setup.py``, ``setup.cfg``,
+    ``package.json``, or ``.any2md.toml.boundary``) so config in
+    unrelated parent directories cannot leak into a project's run.
+    """
+    cur = (start or Path.cwd()).resolve()
+    while True:
+        candidate = cur / ".any2md.toml"
+        if candidate.is_file():
+            return candidate
+        if any((cur / m).exists() for m in _PROJECT_BOUNDARY_MARKERS):
+            return None
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+```
+
+- [ ] **Step 4: Add `--no-config` CLI flag**
+
+In `any2md/cli.py`, near the other CLI argument definitions:
+```python
+parser.add_argument(
+    "--no-config",
+    action="store_true",
+    help="Skip .any2md.toml auto-discovery (overrides default walk-up).",
+)
+```
+
+Then change the `discovered = discover_config()` line to:
+```python
+discovered = None if args.no_config else discover_config()
+```
+
+Run tests:
+```bash
+python -m pytest tests/unit/test_config_walkup.py tests/unit/test_config.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add any2md/config.py any2md/cli.py tests/unit/test_config_walkup.py
+git commit -m "$(cat <<'EOF'
+security(F3): bound TOML auto-discovery at project markers + --no-config
+
+discover_config now stops at the first ancestor containing .git /
+pyproject.toml / setup.py / setup.cfg / package.json /
+.any2md.toml.boundary. Prevents a malicious .any2md.toml in a parent
+directory (or /tmp, ~) from polluting unrelated any2md runs.
+
+New --no-config flag fully disables discovery.
+EOF
+)"
+```
+
+---
+
+## Task 8: DOCX zip-bomb guard (F4)
+
+**Files:**
+- Modify: `any2md/converters/docx.py` (`_safe_zip_open` helper + use in `_read_docx_metadata`)
+- Test: `tests/unit/test_zipbomb_guard.py` (new)
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/unit/test_zipbomb_guard.py`:
+```python
+"""Tests for _safe_zip_open in any2md/converters/docx.py (F4)."""
+
+from __future__ import annotations
+
+import struct
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from any2md.converters.docx import _MAX_DOCX_METADATA_SIZE, _safe_zip_open
+
+
+def _make_zip_with_lying_size(out: Path, member: str, declared_size: int):
+    """Build a zip whose ``member`` declares ``declared_size`` uncompressed.
+
+    We write 1 KB of real content but tamper the central directory's
+    uncompressed size so ``ZipInfo.file_size`` reports ``declared_size``.
+    """
+    real_body = b"<x/>"
+    with zipfile.ZipFile(out, "w") as z:
+        z.writestr(member, real_body)
+    # Re-open to mutate the central directory's "uncompressed size"
+    raw = out.read_bytes()
+    # Find the central directory entry signature (PK\x01\x02) and the
+    # 'uncompressed size' field at offset +24 (4 bytes, little-endian).
+    sig = b"PK\x01\x02"
+    idx = raw.find(sig)
+    assert idx != -1
+    raw = (
+        raw[: idx + 24]
+        + struct.pack("<I", declared_size)
+        + raw[idx + 28 :]
+    )
+    out.write_bytes(raw)
+
+
+def test_safe_zip_open_accepts_normal(tmp_path):
+    z = tmp_path / "ok.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        zf.writestr("a.xml", b"<x/>")
+    with zipfile.ZipFile(z) as zf:
+        f = _safe_zip_open(zf, "a.xml")
+        assert f.read() == b"<x/>"
+
+
+def test_safe_zip_open_rejects_oversized(tmp_path):
+    z = tmp_path / "bomb.zip"
+    _make_zip_with_lying_size(z, "core.xml", _MAX_DOCX_METADATA_SIZE + 1)
+    with zipfile.ZipFile(z) as zf:
+        with pytest.raises(ValueError, match="exceeds"):
+            _safe_zip_open(zf, "core.xml")
+```
+
+- [ ] **Step 2: Run test, expect failures**
+
+```bash
+python -m pytest tests/unit/test_zipbomb_guard.py -v 2>&1 | tail -10
+```
+
+Expected: ImportError on `_MAX_DOCX_METADATA_SIZE` and `_safe_zip_open`.
+
+- [ ] **Step 3: Implement guard in `any2md/converters/docx.py`**
+
+Near the top of the file (after imports), add:
+```python
+_MAX_DOCX_METADATA_SIZE = 1 * 1024 * 1024  # 1 MB; core.xml/app.xml are typically <10 KB
+
+
+def _safe_zip_open(z: zipfile.ZipFile, name: str, max_size: int = _MAX_DOCX_METADATA_SIZE):
+    """Open a fixed-name DOCX member after a declared-size sanity check.
+
+    Defends against zip-bomb amplification: a malicious DOCX can declare
+    an uncompressed_size of 10 GB for ``core.xml`` and bomb the XML
+    parser. Raises ``ValueError`` (caught by ``convert_docx``'s existing
+    handler → file fails cleanly).
+    """
+    info = z.getinfo(name)
+    if info.file_size > max_size:
+        raise ValueError(
+            f"{name} declared size {info.file_size} exceeds {max_size}-byte limit"
+        )
+    return z.open(name)
+```
+
+Then in `_read_docx_metadata`, replace BOTH `with z.open("docProps/core.xml") as f:` and `with z.open("docProps/app.xml") as f:` with `with _safe_zip_open(z, "docProps/core.xml") as f:` (and analogously for `app.xml`).
+
+- [ ] **Step 4: Run targeted tests + full suite**
+
+```bash
+python -m pytest tests/unit/test_zipbomb_guard.py tests/integration/test_docx_mammoth_fallback.py -q
+python -m pytest tests/ -q 2>&1 | tail -3
+```
+
+Expected: all pass, no regressions.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add any2md/converters/docx.py tests/unit/test_zipbomb_guard.py
+git commit -m "$(cat <<'EOF'
+security(F4): pre-check declared uncompressed size on DOCX metadata reads
+
+A malicious DOCX can declare uncompressed_size of 10GB for core.xml /
+app.xml and bomb ET.parse. _safe_zip_open enforces a 1 MB cap on the
+two known-small metadata members; oversized members raise ValueError
+which the existing handler converts to a clean per-file FAIL.
+
+Real DOCX core.xml/app.xml are typically <10 KB, so the cap has 100x
+headroom for legitimate input.
+EOF
+)"
+```
+
+---
+
+## Task 9: `atomic_write_text` + symlink rejection (F6)
+
+**Files:**
+- Modify: `any2md/utils.py` (new `atomic_write_text` function)
+- Modify: `any2md/converters/pdf.py`, `docx.py`, `html.py`, `txt.py` (replace `out_path.write_text(...)` calls)
+- Modify: `any2md/converters/pdf.py` (image-extraction symlink check)
+- Test: `tests/unit/test_atomic_write.py` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_atomic_write.py`:
+```python
+"""Tests for atomic_write_text (F6)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from any2md.utils import atomic_write_text
+
+
+def test_writes_new_file(tmp_path):
+    out = tmp_path / "x.md"
+    atomic_write_text(out, "hello")
+    assert out.read_text(encoding="utf-8") == "hello"
+
+
+def test_overwrites_existing_file(tmp_path):
+    out = tmp_path / "x.md"
+    out.write_text("old", encoding="utf-8")
+    atomic_write_text(out, "new")
+    assert out.read_text(encoding="utf-8") == "new"
+
+
+def test_refuses_pre_existing_symlink(tmp_path):
+    target = tmp_path / "real.md"
+    target.write_text("victim", encoding="utf-8")
+    link = tmp_path / "out.md"
+    os.symlink(target, link)
+    with pytest.raises(ValueError, match="symlink"):
+        atomic_write_text(link, "evil")
+    # Target unchanged
+    assert target.read_text(encoding="utf-8") == "victim"
+
+
+def test_no_partial_file_on_exception(tmp_path, monkeypatch):
+    out = tmp_path / "x.md"
+    # Make os.replace fail to simulate mid-write failure
+    real_replace = os.replace
+
+    def boom(*_a, **_kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("any2md.utils.os.replace", boom)
+    with pytest.raises(OSError):
+        atomic_write_text(out, "hello")
+    assert not out.exists()
+    # No leftover .any2md-*.tmp files
+    leftovers = list(tmp_path.glob(".any2md-*.tmp"))
+    assert leftovers == []
+
+
+def test_creates_parent_dir_if_missing(tmp_path):
+    out = tmp_path / "deep" / "nested" / "x.md"
+    atomic_write_text(out, "hi")
+    assert out.read_text(encoding="utf-8") == "hi"
+```
+
+- [ ] **Step 2: Run tests, expect failures**
+
+```bash
+python -m pytest tests/unit/test_atomic_write.py -v 2>&1 | tail -10
+```
+
+Expected: ImportError on `atomic_write_text`.
+
+- [ ] **Step 3: Implement `atomic_write_text`**
+
+Add to `any2md/utils.py`:
+```python
+import os
+import tempfile
+
+
+def atomic_write_text(out_path: Path, content: str) -> None:
+    """Write text atomically; refuse to clobber a symlink target.
+
+    Creates a sibling temp file in the same directory, fsyncs, then
+    ``os.replace``s it over ``out_path``. Defends against (a) overwrite
+    of a symlink target — pre-existing symlink raises ``ValueError`` —
+    and (b) partial-write windows for concurrent readers.
+    """
+    if out_path.is_symlink():
+        raise ValueError(f"refusing to write through symlink: {out_path}")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=".any2md-", suffix=".tmp", dir=out_path.parent
+    )
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, out_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+```
+
+- [ ] **Step 4: Wire into all converters**
+
+In each of `any2md/converters/pdf.py`, `docx.py`, `html.py`, `txt.py`:
+1. Add to imports: `from any2md.utils import atomic_write_text` (most already import other utils).
+2. Replace `out_path.write_text(full, encoding="utf-8", newline="\n")` (or similar `.write_text(...)`) with `atomic_write_text(out_path, full)`. There is exactly one such call per converter. Search:
+   ```bash
+   grep -n "write_text" any2md/converters/*.py
+   ```
+
+In `any2md/converters/pdf.py` image-extraction loop (search for `pil_image.save(str(img_path))` — around line 151), add a symlink check immediately before the save:
+```python
+if img_path.exists() and img_path.is_symlink():
+    print(
+        f"  WARN: skipping image {i + 1}: target is a symlink.",
+        file=sys.stderr,
+    )
+    continue
+pil_image.save(str(img_path))
+```
+
+- [ ] **Step 5: Run full test suite + commit**
+
+```bash
+python -m pytest tests/ -q 2>&1 | tail -3
+```
+
+Expected: 290+ tests pass.
+
+```bash
+git add any2md/utils.py any2md/converters/pdf.py any2md/converters/docx.py any2md/converters/html.py any2md/converters/txt.py tests/unit/test_atomic_write.py
+git commit -m "$(cat <<'EOF'
+security(F6): atomic-write outputs + reject pre-existing symlinks
+
+New any2md.utils.atomic_write_text writes via tempfile in the parent
+dir, fsyncs, then os.replace. Refuses if out_path is a pre-existing
+symlink — defends against an attacker who pre-plants a symlink at the
+output path pointing at ~/.ssh/authorized_keys etc.
+
+All four converters (pdf/docx/html/txt) wired through it. PDF image
+extraction also checks for symlinks before pil_image.save (PIL has no
+atomic-write helper; we accept partial-write but not symlink redirect).
+EOF
+)"
+```
+
+---
+
+## Task 10: Control-char sanitizer for Docling warnings (F2)
+
+**Files:**
+- Modify: `any2md/converters/docx.py` (add `_LOG_CONTROL_CHARS_RE` + `_sanitize_log_text`; wire into the warning forward)
+- Test: `tests/unit/test_log_sanitizer.py` (new)
+
+- [ ] **Step 1: Write failing test**
+
+Create `tests/unit/test_log_sanitizer.py`:
+```python
+"""Tests for Docling-warning control-char sanitizer (F2)."""
+
+from __future__ import annotations
+
+from any2md.converters.docx import _sanitize_log_text
+
+
+def test_strips_ansi_escape():
+    s = "msg \x1b[31mRED\x1b[0m end"
+    assert _sanitize_log_text(s) == "msg [31mRED[0m end"
+
+
+def test_strips_null_byte():
+    assert _sanitize_log_text("a\x00b") == "ab"
+
+
+def test_preserves_printable_ascii():
+    s = "Plain ASCII text: hello, world! 123."
+    assert _sanitize_log_text(s) == s
+
+
+def test_preserves_tab_and_newline():
+    # \t and \n are explicitly allowed (not in the strip class)
+    assert _sanitize_log_text("a\tb\nc") == "a\tb\nc"
+
+
+def test_strips_c1_controls():
+    # 0x80-0x9f range
+    assert _sanitize_log_text("a\x85b\x9fc") == "abc"
+```
+
+- [ ] **Step 2: Run test, expect failure**
+
+```bash
+python -m pytest tests/unit/test_log_sanitizer.py -v 2>&1 | tail -10
+```
+
+Expected: ImportError on `_sanitize_log_text`.
+
+- [ ] **Step 3: Implement sanitizer**
+
+In `any2md/converters/docx.py`, near the existing regex/constants section, add:
+```python
+import re
+
+_LOG_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+
+
+def _sanitize_log_text(s: str) -> str:
+    """Strip ASCII C0/C1 control chars from a log message before re-emission.
+
+    Defends terminals from ANSI-escape spoofing planted in malicious
+    DOCX content that surfaces as a Docling msword_backend warning.
+    \\t and \\n are preserved (not in the strip class).
+    """
+    return _LOG_CONTROL_CHARS_RE.sub("", s)
+```
+
+Update the existing forward site in `convert_docx`:
+```python
+add_warnings(
+    [f"docling.msword_backend: {_sanitize_log_text(m)}" for m in docling_warnings]
+)
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+python -m pytest tests/unit/test_log_sanitizer.py tests/integration/test_docx_fallback_on_warn.py -q
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add any2md/converters/docx.py tests/unit/test_log_sanitizer.py
+git commit -m "$(cat <<'EOF'
+security(F2): strip control chars from forwarded Docling warnings
+
+A malicious DOCX could embed ANSI escape sequences in content that
+Docling surfaces as a msword_backend warning; we then echo the warning
+into stderr and into add_warnings(). Without sanitization the escape
+sequences could spoof terminal output (CWE-150).
+
+_sanitize_log_text strips C0 (\\x00-\\x08, \\x0b, \\x0c, \\x0e-\\x1f, \\x7f)
+and C1 (\\x80-\\x9f) controls; \\t and \\n are preserved.
+EOF
+)"
+```
+
+---
+
+## Task 11: `safe_dir_name` + PDF stem hardening (F11)
+
+**Files:**
+- Modify: `any2md/utils.py` (new `safe_dir_name`)
+- Modify: `any2md/converters/pdf.py` (use `safe_dir_name(pdf_path.stem)` for image dir)
+- Test: `tests/unit/test_safe_dir_name.py` (new)
+
+- [ ] **Step 1: Write failing tests**
+
+Create `tests/unit/test_safe_dir_name.py`:
+```python
+"""Tests for safe_dir_name (F11: PDF image dir hardening)."""
+
+from __future__ import annotations
+
+import pytest
+
+from any2md.utils import safe_dir_name
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("normal-doc_v2", "normal-doc_v2"),
+        ("..", "untitled"),
+        ("...", "untitled"),
+        ("a/b/c", "a_b_c"),
+        ("hello world", "hello_world"),
+        ("", "untitled"),
+        ("___", "untitled"),
+        ("file.with.dots", "file_with_dots"),
+        ("emoji \U0001F4A9 here", "emoji___here"),
+    ],
+)
+def test_safe_dir_name(raw, expected):
+    assert safe_dir_name(raw) == expected
+```
+
+- [ ] **Step 2: Run tests, expect failures**
+
+```bash
+python -m pytest tests/unit/test_safe_dir_name.py -v 2>&1 | tail -10
+```
+
+Expected: ImportError on `safe_dir_name`.
+
+- [ ] **Step 3: Implement helper**
+
+Add to `any2md/utils.py`:
+```python
+def safe_dir_name(name: str) -> str:
+    """Conservative directory-name sanitizer: alphanumeric/_/- only.
+
+    Used for output sub-directories whose name comes from an untrusted
+    input filename stem. Replaces every non-allowed char with ``_``,
+    collapses runs of ``_``, strips leading/trailing ``_``, and falls
+    back to ``"untitled"`` for empty results.
+    """
+    cleaned = re.sub(r"[^A-Za-z0-9_-]", "_", name)
+    cleaned = _COLLAPSE_UNDERSCORES_RE.sub("_", cleaned)
+    cleaned = cleaned.strip("_") or "untitled"
+    return cleaned
+```
+
+(`_COLLAPSE_UNDERSCORES_RE` already exists in `utils.py` from `sanitize_filename`.)
+
+- [ ] **Step 4: Wire into `pdf.py` image-extraction**
+
+In `any2md/converters/pdf.py`, where `images_dir = output_dir / "images" / pdf_path.stem` is set:
+```python
+from any2md.utils import safe_dir_name  # add to imports near top
+...
+images_dir = output_dir / "images" / safe_dir_name(pdf_path.stem)
+```
+
+- [ ] **Step 5: Run tests + commit**
+
+```bash
+python -m pytest tests/unit/test_safe_dir_name.py tests/ -q 2>&1 | tail -3
+```
+
+Expected: green.
+
+```bash
+git add any2md/utils.py any2md/converters/pdf.py tests/unit/test_safe_dir_name.py
+git commit -m "$(cat <<'EOF'
+security(F11): sanitize PDF stem before using as images dir name
+
+Edge case: a PDF named '...pdf' had Path.stem == '..' which resolved
+to output_dir/images/.. (parent), co-mingling images with markdown.
+safe_dir_name maps anything outside [A-Za-z0-9_-] to _, collapses runs,
+falls back to 'untitled' for empty results.
+EOF
+)"
+```
+
+---
+
+## Task 12: CHANGELOG + final verification
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Write `[1.0.6]` CHANGELOG section**
+
+At the top of `CHANGELOG.md`, just after the header, insert:
+```markdown
+## [1.0.6] — <set release date here, e.g. 2026-04-28>
+
+Security hardening release. Closes 8 findings from the 2026-04-27
+multi-tool audit (semgrep+trivy+gitleaks+bandit+pip-audit+manual
+review). No public API changes; behavior unchanged for legitimate
+inputs.
+
+### Security
+
+- **F1 (HIGH)** SSRF: replaced `trafilatura.fetch_url` and the bare
+  `urllib.request.urlopen` paths with a new `any2md/_http.py` module
+  that does manual redirect walking with per-hop revalidation. Defends
+  against DNS-rebinding and redirect-based bypass of the IP-class
+  check. New `validate_url` rejects non-http(s) schemes and
+  private/loopback/link-local/reserved targets. 20 MB body cap.
+  Applied to `convert_url`, `_http_last_modified`, and arxiv lookup.
+- **F5 (MED)** `--meta` integrity: `content_hash`, `extracted_via`,
+  `source_file`, `lane`, `token_estimate`, `recommended_chunk_level`
+  are now **reserved** and silently filtered from `--meta` /
+  `--meta-file` / `.any2md.toml` overrides with a stderr `WARN` per
+  drop. Defense-in-depth filter also runs inside `frontmatter.compose`.
+- **F3 (MED)** TOML auto-discovery now stops at the first ancestor
+  containing `.git` / `pyproject.toml` / `setup.py` / `setup.cfg` /
+  `package.json` / `.any2md.toml.boundary`. New `--no-config` flag
+  fully disables discovery.
+- **F4 (MED)** DOCX zip-bomb: `_safe_zip_open` enforces a 1 MB cap on
+  the declared uncompressed size of `core.xml` and `app.xml` before
+  parsing. Oversized members raise `ValueError` → clean per-file FAIL.
+- **F-CVE (MED)** Dependency floors bumped: `lxml>=6.1.0,<7`
+  (CVE-2026-41066), `pillow>=12.2.0,<13` (CVE-2026-25990,
+  CVE-2026-40192), `urllib3>=2.6.3,<3` (CVE-2026-21441). All ranges
+  acquire upper bounds (compat envelope). `requirements.txt` becomes
+  a development/CI lockfile with exact pins.
+- **F6 (LOW)** Atomic writes: new `atomic_write_text` writes via
+  `tempfile.mkstemp` + `os.replace`. Refuses to overwrite a
+  pre-existing symlink at the output path. Wired through
+  `pdf/docx/html/txt` converters; PDF image extraction adds a symlink
+  check before `pil_image.save`.
+- **F2 (LOW)** Control-char sanitizer strips C0/C1 controls (preserves
+  `\t`, `\n`) from captured Docling `msword_backend` warnings before
+  forwarding them to `collected_warnings()` and stderr. Defends
+  terminals from ANSI-escape spoofing.
+- **F11 (LOW)** PDF image-dir name now goes through `safe_dir_name`
+  (alphanumeric/`_`/`-` only). Closes a `Path.stem == ".."` corner
+  case that co-mingled images with markdown outputs.
+- **XXE defense-in-depth**: migrated `xml.etree.ElementTree` →
+  `defusedxml.ElementTree` in `docx.py` and `heuristics.py`. Stdlib
+  was already safe in Python 3.7+; this silences bandit B405/B314
+  permanently and protects against future stdlib regressions.
+
+### Added
+- New module `any2md/_http.py` (validate_url, safe_fetch).
+- New CLI flag `--no-config`.
+- New helpers `any2md.utils.atomic_write_text` and `safe_dir_name`.
+- New runtime dependency: `defusedxml>=0.7.1,<1`.
+
+### Tests
+- 7 new unit-test files (~30 tests): `test_http_safe.py`,
+  `test_meta_reserved_keys.py`, `test_config_walkup.py`,
+  `test_zipbomb_guard.py`, `test_atomic_write.py`,
+  `test_safe_dir_name.py`, `test_log_sanitizer.py`.
+- Existing 290 tests continue to pass without snapshot updates.
+
+### Audit summary
+
+| ID | Title | Severity |
+|----|-------|----------|
+| F1 | SSRF: DNS rebind + redirect bypass | High |
+| F5 | `--meta` clobbers reserved frontmatter | Medium |
+| F3 | TOML discovery walks above project root | Medium |
+| F4 | DOCX zip-bomb amplification | Medium |
+| F-CVE | Transitive deps with known CVEs | Medium |
+| F6 | Symlink-following on output writes | Low |
+| F2 | Control-char passthrough in Docling logs | Low |
+| F11 | PDF stem `..` corner case | Low |
+
+```
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+python -m pytest tests/ -q 2>&1 | tail -3
+```
+
+Expected: 320+ passed, 1 skipped (290 baseline + ~30 new).
+
+- [ ] **Step 3: Run ruff + bandit**
+
+```bash
+ruff check . && ruff format --check .
+bandit -r any2md scripts -ll
+```
+
+Expected: ruff green; bandit reports fewer findings (XXE B405/B314 gone after defusedxml migration; B310 gone after _http.py centralization). B110 try/except/pass remain in arxiv `_warn` and `_http_last_modified` — acceptable best-effort patterns.
+
+- [ ] **Step 4: Re-run the 5 DOCX acceptance test for regression**
+
+```bash
+rm -rf /tmp/any2md-v1.0.6-acceptance && mkdir -p /tmp/any2md-v1.0.6-acceptance
+find "/Users/klambros/Library/CloudStorage/OneDrive-RockCyber/AI/AI Papers/" \
+  -maxdepth 1 -type f -iname "*.docx" -print0 | \
+  xargs -0 -I{} any2md -H -f -o /tmp/any2md-v1.0.6-acceptance "{}" 2>&1 | \
+  grep -E "(FALLBACK:|OK:|Done in)"
+```
+
+Expected: same per-file pattern as v1.0.5 (4 clean docling, 1 FALLBACK on `AI_Policy_Template_…` recovering ~15,566 words via mammoth). Word counts must match v1.0.5 baseline within ±10 (atomic-write doesn't change content).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "docs(changelog): v1.0.6 security hardening entry"
+```
+
+---
+
+## Task 13: Push, PR, merge, release
+
+**Files:** none (git/gh ops only).
+
+- [ ] **Step 1: Push branch + open PR**
+
+```bash
+git push origin feat/v1.0.6-security-hardening
+gh pr create --title "v1.0.6: Security hardening — close 8 audit findings" --body "$(cat <<'EOF'
+## Summary
+Closes all 8 findings from the 2026-04-27 multi-tool security audit (semgrep + trivy + gitleaks + bandit + pip-audit + security-engineer agent). No public API changes; behavior unchanged for legitimate inputs.
+
+## Highlights
+- F1 (HIGH) — new `any2md/_http.py` with manual redirect walking + per-hop host revalidation; defeats DNS rebind and redirect-based SSRF.
+- F5 (MED) — reserved-key filter so `--meta content_hash=…` etc. cannot forge derived frontmatter.
+- F3 (MED) — TOML auto-discovery bounded at project markers; new `--no-config` flag.
+- F4 (MED) — DOCX zip-bomb guard (1 MB cap on metadata members).
+- F-CVE — bumps `lxml`, `pillow`, `urllib3` past known CVE versions; adds upper bounds (compat envelope); pins `requirements.txt`.
+- F6/F2/F11 — atomic-write + symlink rejection, control-char sanitizer, PDF stem hardening.
+- XXE defense-in-depth via `defusedxml`.
+
+See `docs/superpowers/specs/2026-04-27-v1.0.6-security-hardening-design.md` for the full design and `CHANGELOG.md` for the per-fix table.
+
+## Test plan
+- [x] 7 new unit-test files (~30 tests) — added.
+- [x] 290 existing tests still pass — verified locally.
+- [x] `ruff check .` and `ruff format --check .` clean.
+- [x] `bandit -r any2md scripts -ll` shows reduced finding count.
+- [x] 5-DOCX acceptance run reproduces v1.0.5 output (no content regression).
+EOF
+)"
+```
+
+- [ ] **Step 2: Wait for CI green**
+
+```bash
+gh pr checks --watch
+```
+
+Expected: 7/7 checks pass (quality, smoke 3.10/3.12/3.13, audit, analyze, CodeQL).
+
+- [ ] **Step 3: Admin-merge with branch-protection workaround**
+
+```bash
+gh api repos/rocklambros/any2md/branches/main/protection > /tmp/bp-main.json
+gh api -X DELETE repos/rocklambros/any2md/branches/main/protection/enforce_admins
+gh pr merge --squash --admin --delete-branch
+gh api -X POST repos/rocklambros/any2md/branches/main/protection/enforce_admins
+```
+
+Expected: PR merged; `enforce_admins` re-enabled.
+
+- [ ] **Step 4: Tag rc1 → TestPyPI**
+
+```bash
+git checkout main && git pull origin main
+git tag v1.0.6-rc1 && git push origin v1.0.6-rc1
+gh release create v1.0.6-rc1 --prerelease \
+  --title "v1.0.6-rc1 — TestPyPI release candidate" \
+  --notes "Security hardening RC. See full notes on v1.0.6 prod release."
+```
+
+Expected: `Release to PyPI` workflow runs; TestPyPI publish completes.
+
+- [ ] **Step 5: Verify TestPyPI wheel + tag prod → PyPI**
+
+```bash
+python -m venv /tmp/v106-venv
+/tmp/v106-venv/bin/pip install --quiet --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ "any2md==1.0.6"
+/tmp/v106-venv/bin/python -c "
+import any2md
+from any2md._http import validate_url, safe_fetch
+from any2md.utils import atomic_write_text, safe_dir_name
+from any2md.frontmatter import filter_reserved_overrides
+print('any2md', any2md.__version__, 'OK')
+"
+```
+
+Expected: `any2md 1.0.6 OK`. (TestPyPI's `tld` squat may break full CLI smoke; direct-import test bypasses it.)
+
+Then prod:
+```bash
+git tag v1.0.6 && git push origin v1.0.6
+gh release create v1.0.6 \
+  --title "v1.0.6 — Security hardening release" \
+  --notes-file /tmp/v1.0.6-release-notes.md   # craft from CHANGELOG
+```
+
+The PyPI publish job will pause at the `pypi` environment gate. Self-approve:
+```bash
+RUN_ID=$(gh run list --workflow=publish.yml --limit 1 --json databaseId --jq '.[0].databaseId')
+ENV_ID=$(gh api repos/rocklambros/any2md/actions/runs/$RUN_ID/pending_deployments --jq '.[0].environment.id')
+gh api -X POST repos/rocklambros/any2md/actions/runs/$RUN_ID/pending_deployments \
+  -F "environment_ids[]=$ENV_ID" -f state=approved \
+  -f comment="Approved for v1.0.6 security hardening release."
+gh run watch $RUN_ID --exit-status
+```
+
+Expected: PyPI publish succeeds.
+
+Final smoke on system Python:
+```bash
+pip uninstall -y any2md
+pip install --upgrade any2md
+any2md --version 2>/dev/null || python -c "import any2md; print(any2md.__version__)"
+any2md --help | grep -E "no-config|fallback-on-warn"
+```
+
+Expected: `1.0.6` printed; both flags visible in `--help`.
+
+---
+
+## Self-review notes
+
+The plan covers every spec section: F1 (Tasks 3+4+5), F2 (Task 10), F3 (Task 7), F4 (Task 8), F5 (Task 6), F6 (Task 9), F11 (Task 11), F-CVE (Task 1), XXE D-i-D (Task 2), CHANGELOG/release (Tasks 12+13). No "TBD" / "implement later" / "fill in details" patterns. Type/symbol consistency: `_RESERVED_OVERRIDE_KEYS`, `filter_reserved_overrides`, `_safe_zip_open`, `_MAX_DOCX_METADATA_SIZE`, `_LOG_CONTROL_CHARS_RE`, `_sanitize_log_text`, `safe_fetch`, `validate_url`, `atomic_write_text`, `safe_dir_name` — names used consistently across tasks. `_PROJECT_BOUNDARY_MARKERS` defined and used in single task (Task 7).

--- a/docs/superpowers/specs/2026-04-27-v1.0.6-security-hardening-design.md
+++ b/docs/superpowers/specs/2026-04-27-v1.0.6-security-hardening-design.md
@@ -1,0 +1,477 @@
+# v1.0.6 — Security Hardening Release
+
+**Date:** 2026-04-27
+**Branch:** `feat/v1.0.6-security-hardening`
+**Target version:** 1.0.6
+**PR target:** `main`
+
+## Problem
+
+A multi-tool security audit run on 2026-04-27 against the v1.0.5 codebase
+(semgrep — broken in env, trivy, gitleaks, bandit, pip-audit, plus a
+manual review by the security-engineer agent and Opus 4.7) surfaced 8
+actionable findings plus a transitive-CVE issue affecting the runtime
+dep tree. The repo itself is clean of secrets and IaC misconfig
+(trivy/gitleaks: 0 findings); the issues are concentrated in the URL
+fetch path, the `--meta` integrity gap, the TOML auto-discovery
+boundary, and DOCX zip-bomb amplification.
+
+This release closes all of them in one PR with backwards-compat
+preserved for legitimate inputs.
+
+## Threat model
+
+- **Untrusted file inputs**: PDF, DOCX, HTML, TXT supplied by the user but potentially malicious (e.g., from email attachments, scraped corpora, third-party datasets).
+- **Untrusted URL inputs**: any HTTP(S) URL on the CLI may resolve to an attacker-controlled host, redirect to an internal target, or be a DNS-rebind trap.
+- **Semi-trusted CLI args / config**: the user typed them, but `.any2md.toml` auto-discovery can pick up files written by other actors on the same filesystem.
+- **Trust boundaries**: the converter is a single-process CLI tool, so kernel-level isolation is not in scope. Defense focuses on input validation, output safety, and provenance integrity.
+
+## Findings (audit summary)
+
+| ID | Title | Sev |
+|---|---|---|
+| F1 | SSRF: DNS rebind + redirect bypass in `convert_url`, `_http_last_modified`, arxiv lookup | High |
+| F5 | `--meta` overrides clobber security-relevant frontmatter (`content_hash`, `extracted_via`, …) | Medium |
+| F3 | TOML config auto-discovery walks above project root | Medium |
+| F4 | DOCX zip-bomb amplification via declared uncompressed size | Medium |
+| F-CVE | Transitive deps with known CVEs (lxml, pillow, urllib3) | Medium |
+| F6 | Symlink-following on output writes / image extraction | Low |
+| F2 | Control-char passthrough in captured Docling warnings | Low |
+| F11 | PDF stem co-mingling images dir with `..` corner case | Low |
+
+Defended (verified during audit, no change needed): XXE, zip-slip,
+YAML deserialization, command injection, no unsafe deserialization
+(no `pickle`/`marshal` usage), GitHub Actions hygiene, secrets in git
+history, IaC misconfig.
+
+## Design
+
+### Fix 1 — SSRF (F1): controlled fetcher, manual redirect walk, per-hop revalidation
+
+**Move the URL-validation + fetch logic into a new module `any2md/_http.py`** so all three callers (`html.py`, `heuristics.py` arxiv lookup, future) share one implementation.
+
+```python
+# any2md/_http.py
+_MAX_REDIRECT_HOPS = 3
+_FETCH_TIMEOUT = 15
+_MAX_RESPONSE_BYTES = 20 * 1024 * 1024  # 20 MB
+_USER_AGENT = "any2md/1.0.6"
+
+
+def validate_url(url: str) -> str | None:
+    """Reject non-http(s), no-host, or private/loopback/link-local/reserved targets.
+
+    Returns an error message, or None if the URL passes initial validation.
+    Note: this is a *one-shot* DNS lookup; rebind protection requires
+    revalidation on each redirect hop (see `safe_fetch`).
+    """
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return f"unsupported scheme: {parsed.scheme!r}"
+    if not parsed.hostname:
+        return f"no hostname in URL: {url}"
+    try:
+        infos = socket.getaddrinfo(parsed.hostname, None, type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        return f"cannot resolve host: {parsed.hostname}"
+    for *_, sockaddr in infos:
+        try:
+            addr = ipaddress.ip_address(sockaddr[0])
+        except ValueError:
+            continue
+        if addr.is_private or addr.is_reserved or addr.is_loopback or addr.is_link_local:
+            return f"URL resolves to disallowed address: {addr}"
+    return None
+
+
+class _NoFollowRedirect(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, *args, **kwargs):  # noqa: ARG002
+        return None  # disable urllib's automatic follow
+
+
+def safe_fetch(
+    url: str, *, method: str = "GET", max_hops: int = _MAX_REDIRECT_HOPS
+) -> tuple[bytes | None, dict | None, str | None]:
+    """Fetch ``url`` with manual redirect walking and per-hop host revalidation.
+
+    Returns ``(body, headers, None)`` on 2xx, or ``(None, None, error)`` on
+    rejection / failure. Each redirect target is re-validated through
+    ``validate_url``; rebinds to private addresses are blocked.
+    """
+    visited: list[str] = []
+    current = url
+    opener = urllib.request.build_opener(_NoFollowRedirect())
+    for hop in range(max_hops + 1):
+        if current in visited:
+            return None, None, "redirect loop"
+        visited.append(current)
+        err = validate_url(current)
+        if err:
+            return None, None, err
+        req = urllib.request.Request(
+            current, method=method, headers={"User-Agent": _USER_AGENT}
+        )
+        try:
+            resp = opener.open(req, timeout=_FETCH_TIMEOUT)
+        except urllib.error.HTTPError as e:
+            if e.code in (301, 302, 303, 307, 308) and hop < max_hops:
+                location = e.headers.get("Location")
+                if not location:
+                    return None, None, f"HTTP {e.code} without Location"
+                current = urllib.parse.urljoin(current, location)
+                continue
+            return None, None, f"HTTP {e.code}"
+        except (urllib.error.URLError, OSError, TimeoutError) as e:
+            return None, None, f"fetch error: {e}"
+        body = resp.read(_MAX_RESPONSE_BYTES + 1)
+        if len(body) > _MAX_RESPONSE_BYTES:
+            return None, None, f"response exceeds {_MAX_RESPONSE_BYTES} bytes"
+        return body, dict(resp.headers), None
+    return None, None, f"too many redirects (>{max_hops})"
+```
+
+**Wire `html.py`** to use `safe_fetch` and pass the body to
+`trafilatura.extract(filecontent=...)` instead of relying on
+`trafilatura.fetch_url`:
+
+```python
+# any2md/converters/html.py
+from any2md._http import safe_fetch
+
+def fetch_url(url: str) -> tuple[str | None, str | None]:
+    body, _headers, err = safe_fetch(url)
+    if err:
+        return None, err
+    if body is None:
+        return None, "no body"
+    return body.decode("utf-8", errors="replace"), None
+
+
+def _http_last_modified(url: str) -> str | None:
+    _body, headers, err = safe_fetch(url, method="HEAD")
+    if err or not headers:
+        return None
+    lm = headers.get("Last-Modified")
+    if not lm:
+        return None
+    try:
+        from email.utils import parsedate_to_datetime
+        return parsedate_to_datetime(lm).date().isoformat()
+    except (TypeError, ValueError):
+        return None
+```
+
+`heuristics.py` arxiv lookup migrates to `safe_fetch` similarly. Since
+the URL is fixed (`https://export.arxiv.org/api/query?...`), the
+practical attack vector is DNS rebind on the fixed host or an
+arxiv-issued redirect to a private host — both now blocked by the
+per-hop revalidation.
+
+`_validate_url_host` in `html.py` is removed; callers now use
+`_http.validate_url` (which also validates scheme — single chokepoint).
+
+### Fix 2 — `--meta` reserved keys (F5): silent filter + stderr warning
+
+Define the reserved set as a module constant in `frontmatter.py` and
+add a filter helper that drops attempts and emits a stderr WARN per
+drop:
+
+```python
+# any2md/frontmatter.py
+_RESERVED_OVERRIDE_KEYS = frozenset({
+    "content_hash",
+    "token_estimate",
+    "recommended_chunk_level",
+    "extracted_via",
+    "source_file",
+    "lane",
+})
+
+
+def filter_reserved_overrides(
+    overrides: Mapping[str, Any] | None, *, source_label: str = "overrides"
+) -> dict[str, Any] | None:
+    """Drop keys reserved for derived values; emit a stderr WARN per drop.
+
+    Operates on the top-level only (reserved keys are flat fields, not
+    nested). Nested dicts under non-reserved keys are returned untouched.
+    """
+    if not overrides:
+        return overrides
+    out: dict[str, Any] = {}
+    for k, v in overrides.items():
+        if k in _RESERVED_OVERRIDE_KEYS:
+            print(
+                f"  WARN: ignoring {source_label} key {k!r} — reserved (derived from source).",
+                file=sys.stderr,
+            )
+            continue
+        out[k] = v
+    return out
+```
+
+Wire into `cli.py` exactly once after all override sources are merged
+(`.any2md.toml` → `--meta-file` → `--meta`):
+
+```python
+# cli.py, after the deep-merge of all override sources
+overrides = filter_reserved_overrides(overrides, source_label="--meta/--meta-file/.any2md.toml")
+```
+
+Defense-in-depth: also call `filter_reserved_overrides` inside
+`frontmatter.compose` so any caller that bypasses CLI cannot smuggle
+reserved keys through. The double-filter is idempotent.
+
+### Fix 3 — TOML walk-up boundary (F3): stop at project markers + `--no-config` flag
+
+```python
+# any2md/config.py
+_PROJECT_BOUNDARY_MARKERS = (
+    ".git",
+    "pyproject.toml",
+    "setup.py",
+    "setup.cfg",
+    "package.json",
+    ".any2md.toml.boundary",
+)
+
+def discover_config(start: Path | None = None) -> Path | None:
+    cur = (start or Path.cwd()).resolve()
+    while True:
+        candidate = cur / ".any2md.toml"
+        if candidate.is_file():
+            return candidate
+        if any((cur / m).exists() for m in _PROJECT_BOUNDARY_MARKERS):
+            return None
+        if cur.parent == cur:
+            return None
+        cur = cur.parent
+```
+
+CLI:
+```python
+parser.add_argument(
+    "--no-config",
+    action="store_true",
+    help="Skip .any2md.toml auto-discovery (overrides default walk-up).",
+)
+# in main():
+discovered = None if args.no_config else discover_config()
+```
+
+### Fix 4 — DOCX zip-bomb guard (F4): pre-check declared uncompressed size
+
+```python
+# any2md/converters/docx.py
+_MAX_DOCX_METADATA_SIZE = 1 * 1024 * 1024  # 1 MB; core.xml/app.xml are typically <10 KB
+
+def _safe_zip_open(z: zipfile.ZipFile, name: str, max_size: int = _MAX_DOCX_METADATA_SIZE):
+    """Open a fixed-name DOCX member after a declared-size sanity check.
+
+    Raises ``ValueError`` if the member declares an uncompressed size
+    above ``max_size`` (defends against compression-ratio amplification).
+    Caller propagates via the existing ``except (OSError, ValueError)``
+    handler, which fails the file with a FAIL line and continues the run.
+    """
+    info = z.getinfo(name)
+    if info.file_size > max_size:
+        raise ValueError(
+            f"{name} declared size {info.file_size} exceeds {max_size}-byte limit"
+        )
+    return z.open(name)
+```
+
+Used at both `core.xml` and `app.xml` open sites in
+`_read_docx_metadata`. No change to Docling's own DOCX parsing — that
+attack surface is upstream.
+
+### Fix 5 — XXE defense-in-depth: migrate to `defusedxml`
+
+Although Python 3.7+ stdlib `xml.etree.ElementTree` disables DTD and
+external entity resolution by default, we migrate to
+`defusedxml.ElementTree` for belt-and-suspenders coverage and to
+silence bandit B405/B314 permanently.
+
+```python
+# any2md/converters/docx.py
+from defusedxml.ElementTree import parse as _xml_parse
+
+# any2md/heuristics.py
+from defusedxml.ElementTree import parse as _xml_parse, fromstring as _xml_fromstring
+```
+
+Add `defusedxml>=0.7.1,<1` to runtime deps.
+
+### Fix 6 — F-CVE: bump dep floors + pin lockfile
+
+`pyproject.toml`:
+```toml
+dependencies = [
+    "pymupdf>=1.24.0,<2",
+    "pymupdf4llm>=0.0.17,<1",
+    "mammoth>=1.6.0,<2",
+    "markdownify>=0.13.0,<2",
+    "trafilatura>=1.12.0,<3",
+    "beautifulsoup4>=4.12.0,<5",
+    "lxml>=6.1.0,<7",        # CVE-2026-41066 fix
+    "pillow>=12.2.0,<13",    # CVE-2026-25990, CVE-2026-40192 fix
+    "urllib3>=2.6.3,<3",     # CVE-2026-21441 fix
+    "defusedxml>=0.7.1,<1",  # XXE defense-in-depth (Fix 5)
+]
+```
+
+`requirements.txt` becomes a development/CI lockfile with exact pins
+to the latest known-good patch version of each dep. (The published
+PyPI distribution uses `pyproject.toml` ranges — users get resolver
+flexibility; CI reproducibility comes from the lockfile.)
+
+### Fix 7 — Symlink + atomic write (F6)
+
+New helper `any2md/utils.py::atomic_write_text`:
+```python
+import os, tempfile
+
+def atomic_write_text(out_path: Path, content: str) -> None:
+    """Write text atomically. Refuses to clobber a symlink target.
+
+    Creates a sibling temp file, fsyncs, then renames over ``out_path``.
+    If ``out_path`` exists and is a symlink, raises ``ValueError`` rather
+    than overwriting whatever the link points to.
+    """
+    if out_path.is_symlink():
+        raise ValueError(f"refusing to write through symlink: {out_path}")
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_str = tempfile.mkstemp(
+        prefix=".any2md-", suffix=".tmp", dir=out_path.parent
+    )
+    tmp_path = Path(tmp_str)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8", newline="\n") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, out_path)
+    except Exception:
+        tmp_path.unlink(missing_ok=True)
+        raise
+```
+
+Replace every `out_path.write_text(full, encoding="utf-8", newline="\n")`
+in `pdf.py`, `docx.py`, `html.py`, `txt.py` with
+`atomic_write_text(out_path, full)`.
+
+For PDF image extraction (`pdf.py:151`), add a symlink check before
+`pil_image.save(...)` (PIL has no atomic-write helper; partial-write
+risk on images is acceptable, but symlink redirection is not):
+```python
+if img_path.exists() and img_path.is_symlink():
+    print(f"  WARN: skipping image {i+1}: target is a symlink.", file=sys.stderr)
+    continue
+pil_image.save(str(img_path))
+```
+
+### Fix 8 — Control-char sanitizer (F2)
+
+```python
+# any2md/converters/docx.py
+_LOG_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+
+def _sanitize_log_text(s: str) -> str:
+    """Strip ASCII/C1 control chars from a log message before re-emission.
+
+    Defends terminals from ANSI-escape spoofing planted in malicious DOCX
+    content that surfaces as a Docling msword_backend warning.
+    """
+    return _LOG_CONTROL_CHARS_RE.sub("", s)
+```
+
+Apply at the forwarding site:
+```python
+add_warnings(
+    [f"docling.msword_backend: {_sanitize_log_text(m)}" for m in docling_warnings]
+)
+```
+
+### Fix 9 — PDF stem hardening (F11)
+
+```python
+# any2md/utils.py
+def safe_dir_name(name: str) -> str:
+    """Conservative directory-name sanitizer: alphanumeric/_/- only."""
+    cleaned = re.sub(r"[^A-Za-z0-9_-]", "_", name)
+    cleaned = cleaned.strip("_") or "untitled"
+    return cleaned
+```
+
+Wired into `pdf.py:143`:
+```python
+images_dir = output_dir / "images" / safe_dir_name(pdf_path.stem)
+```
+
+### Out of scope for v1.0.6
+
+- Replacing trafilatura with a different HTML library.
+- Switching from `urllib` to `httpx` / `requests` (no clear benefit; adds dep).
+- Sandboxing Docling/pymupdf model evaluation.
+- Bandit B110 (`try/except/pass`) in `_http_last_modified` and arxiv
+  parse — legitimate best-effort patterns; tagged with `# nosec B110`
+  + rationale comment.
+- Network-level egress controls / WAF (out of CLI tool scope).
+
+## Test plan
+
+New unit-test files (target: 7 files, ~30 tests total):
+
+| File | Coverage |
+|---|---|
+| `tests/unit/test_http_safe.py` | `validate_url` accepts/rejects table; `safe_fetch` redirect walking with `urllib.request` mocks; max-hops enforcement; loop detection; response-size cap; HEAD method path |
+| `tests/unit/test_meta_reserved_keys.py` | Each reserved key dropped + warn emitted; non-reserved keys preserved; nested dict under non-reserved key untouched; `None` overrides round-trip |
+| `tests/unit/test_config_walkup.py` | Stops at `.git`; stops at `pyproject.toml`; reaches root if no markers; honors `.any2md.toml.boundary`; `--no-config` integration test in `tests/cli` |
+| `tests/unit/test_zipbomb_guard.py` | Synthetic DOCX with declared `file_size > 1 MB` for `core.xml` raises ValueError; legitimate small core.xml passes |
+| `tests/unit/test_atomic_write.py` | Refuses pre-existing symlink; temp file cleaned up on exception during write; new content visible after `os.replace`; correct content + permissions on overwrite |
+| `tests/unit/test_safe_dir_name.py` | `..` → `untitled`; alphanumeric preserved; punctuation collapsed to `_`; empty input → `untitled` |
+| `tests/unit/test_log_sanitizer.py` | ANSI escape stripped; CR/LF preserved; null byte stripped; printable ASCII preserved |
+
+Modified tests:
+
+- `tests/integration/test_html_trafilatura.py` — add SSRF rejection scenarios using stub `urllib.request` resolver / connector.
+- `tests/integration/test_docx_fallback_on_warn.py` — assert sanitized warning text in `collected_warnings()` when synthetic warning contains `\x1b[`.
+
+All 290 existing tests must continue to pass without snapshot updates
+(behavior unchanged for non-malicious inputs).
+
+## Backwards-compat impact
+
+| Surface | Change | Impact |
+|---|---|---|
+| `trafilatura.fetch_url` → custom fetcher | URLs needing >3 redirect hops fail with clear error; URLs to private IPs (incl. via redirect) now reliably blocked | Low — most legit URLs use ≤2 redirects |
+| `--meta content_hash=…` etc. | Now silently filtered with stderr WARN; conversion succeeds with derived value | Low — CI sees a new WARN line; no exit-code change |
+| TOML walk-up boundary | `.any2md.toml` outside project root no longer picked up if a marker exists in between | Low — fix is to relocate config or add `.any2md.toml.boundary` in the desired root |
+| Atomic write + symlink rejection | Pre-existing symlink at output target now errors instead of silently following | Low — previously a misuse; now an explicit refusal |
+| New `defusedxml` runtime dep | Adds one tiny pure-Python dep | None at runtime; small install-time impact |
+| Dep floor bumps | Forces `lxml>=6.1.0`, `pillow>=12.2.0`, `urllib3>=2.6.3` | Users on Python <3.10 may not have a compatible wheel; fresh `pip install` triggers an upgrade of these three packages in shared envs |
+
+No public-API breaks. No CLI flag removals. No frontmatter schema changes.
+
+## Release sequence
+
+1. Branch `feat/v1.0.6-security-hardening` (already created at design-doc commit).
+2. Implementation: atomic commits per finding (clean review path, selective revert if needed). Order:
+   - F-CVE / dep bumps (mechanical)
+   - F1 (largest change; new `_http.py`)
+   - F5, F3, F4 (medium)
+   - F6, F2, F11 (low)
+   - Tests written alongside each commit (TDD).
+3. Update `CHANGELOG.md` `[Unreleased]` → `[1.0.6] — <release-date>` with the audit summary table + per-fix bullet points.
+4. Bump `any2md/__init__.py::__version__` 1.0.5 → 1.0.6.
+5. Open PR. Resolve self-merge protection by toggling `enforce_admins` (same workaround as v1.0.5).
+6. Tag `v1.0.6-rc1` → GitHub prerelease → TestPyPI publish → smoke verify wheel.
+7. Tag `v1.0.6` → GitHub release → approve `pypi` env gate → PyPI publish.
+8. `pip install --upgrade any2md` on system Python; smoke `any2md --help` for `--no-config`.
+9. Re-run the 5 DOCX files from the v1.0.5 acceptance test as regression check.
+
+## References
+
+- Audit report: in-conversation, 2026-04-27 (semgrep-broken; bandit/trivy/gitleaks/pip-audit + security-engineer agent).
+- Trafilatura `extract(filecontent=…, url=…)` accepts pre-fetched HTML (verified via `inspect.signature`).
+- CVE fix versions verified against pip-audit JSON `fix_versions` field (2026-04-27).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,13 +19,16 @@ classifiers = [
     "Topic :: Text Processing :: Markup :: Markdown",
 ]
 dependencies = [
-    "pymupdf>=1.24.0",
-    "pymupdf4llm>=0.0.17",
-    "mammoth>=1.6.0",
-    "markdownify>=0.13.0",
-    "trafilatura>=1.12.0",
-    "beautifulsoup4>=4.12.0",
-    "lxml>=5.0.0",
+    "pymupdf>=1.24.0,<2",
+    "pymupdf4llm>=0.0.17,<1",
+    "mammoth>=1.6.0,<2",
+    "markdownify>=0.13.0,<2",
+    "trafilatura>=1.12.0,<3",
+    "beautifulsoup4>=4.12.0,<5",
+    "lxml>=6.1.0,<7",        # CVE-2026-41066 fix
+    "pillow>=12.2.0,<13",    # CVE-2026-25990, CVE-2026-40192 fix
+    "urllib3>=2.6.3,<3",     # CVE-2026-21441 fix
+    "defusedxml>=0.7.1,<1",  # XXE defense-in-depth (Task P2)
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,10 @@
-pymupdf>=1.24.0
-pymupdf4llm>=0.0.17
-mammoth>=1.6.0
-markdownify>=0.13.0
-trafilatura>=1.12.0
-beautifulsoup4>=4.12.0
-lxml>=5.0.0
+pymupdf==1.27.2.3
+pymupdf4llm==0.3.4
+mammoth==1.12.0
+markdownify==1.2.2
+trafilatura==2.0.0
+beautifulsoup4==4.14.3
+lxml==6.1.0
+pillow==12.2.0
+urllib3==2.6.3
+defusedxml==0.7.1

--- a/tests/integration/test_html_trafilatura.py
+++ b/tests/integration/test_html_trafilatura.py
@@ -27,3 +27,82 @@ def test_html_local_file_emits_v1_frontmatter(fixture_dir, tmp_output_dir):
     assert "Site footer" not in body
     # body content present
     assert "Test Article" in fm["title"] or "Test Article" in body
+
+
+# ---------- SSRF integration tests (v1.0.6 / F1) ----------
+
+import socket
+import urllib.error
+from email.message import Message
+from io import BytesIO
+
+import any2md.converters.html as html_mod
+
+
+class _FakeResp:
+    def __init__(self, body: bytes, headers: dict[str, str] | None = None):
+        self._buf = BytesIO(body)
+        m = Message()
+        for k, v in (headers or {}).items():
+            m[k] = v
+        self.headers = m
+
+    def read(self, n: int | None = None) -> bytes:
+        return self._buf.read(n) if n is not None else self._buf.read()
+
+
+def _http_err(code: int, location: str | None = None):
+    m = Message()
+    if location:
+        m["Location"] = location
+    return urllib.error.HTTPError("x", code, "redir", m, None)
+
+
+class _FakeOpener:
+    def __init__(self, seq):
+        self.seq = list(seq)
+        self.calls = []
+
+    def open(self, req, timeout):
+        self.calls.append(req.full_url)
+        r = self.seq.pop(0)
+        if isinstance(r, urllib.error.HTTPError):
+            raise r
+        return r
+
+
+def _stub_dns(monkeypatch, mapping):
+    def fake(host, *_a, **_kw):
+        ip = mapping.get(host, "1.1.1.1")
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0))]
+
+    monkeypatch.setattr("any2md._http.socket.getaddrinfo", fake)
+
+
+def _patch_opener(monkeypatch, opener):
+    monkeypatch.setattr(
+        "any2md._http.urllib.request.build_opener", lambda *_: opener
+    )
+
+
+def test_fetch_url_rejects_redirect_to_metadata_endpoint(monkeypatch):
+    _stub_dns(
+        monkeypatch,
+        {"public.example": "1.1.1.1", "rebound.example": "169.254.169.254"},
+    )
+    opener = _FakeOpener([_http_err(302, "http://rebound.example/")])
+    _patch_opener(monkeypatch, opener)
+    body, err = html_mod.fetch_url("https://public.example/")
+    assert body is None
+    assert err and "disallowed" in err
+
+
+def test_fetch_url_rejects_file_scheme(monkeypatch):
+    body, err = html_mod.fetch_url("file:///etc/passwd")
+    assert body is None
+    assert err and "scheme" in err
+
+
+def test_http_last_modified_validates_host(monkeypatch):
+    _stub_dns(monkeypatch, {"meta.example": "169.254.169.254"})
+    assert html_mod._http_last_modified("http://meta.example/") is None

--- a/tests/integration/test_html_trafilatura.py
+++ b/tests/integration/test_html_trafilatura.py
@@ -1,7 +1,13 @@
 """Integration test: HTML converter end-to-end."""
 
+import socket
+import urllib.error
+from email.message import Message
+from io import BytesIO
+
 import yaml
 
+import any2md.converters.html as html_mod
 from any2md.converters.html import convert_html
 from any2md.pipeline import PipelineOptions
 
@@ -30,13 +36,6 @@ def test_html_local_file_emits_v1_frontmatter(fixture_dir, tmp_output_dir):
 
 
 # ---------- SSRF integration tests (v1.0.6 / F1) ----------
-
-import socket
-import urllib.error
-from email.message import Message
-from io import BytesIO
-
-import any2md.converters.html as html_mod
 
 
 class _FakeResp:
@@ -80,9 +79,7 @@ def _stub_dns(monkeypatch, mapping):
 
 
 def _patch_opener(monkeypatch, opener):
-    monkeypatch.setattr(
-        "any2md._http.urllib.request.build_opener", lambda *_: opener
-    )
+    monkeypatch.setattr("any2md._http.urllib.request.build_opener", lambda *_: opener)
 
 
 def test_fetch_url_rejects_redirect_to_metadata_endpoint(monkeypatch):

--- a/tests/unit/test_atomic_write.py
+++ b/tests/unit/test_atomic_write.py
@@ -1,0 +1,52 @@
+"""Tests for atomic_write_text (F6)."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from any2md.utils import atomic_write_text
+
+
+def test_writes_new_file(tmp_path):
+    out = tmp_path / "x.md"
+    atomic_write_text(out, "hello")
+    assert out.read_text(encoding="utf-8") == "hello"
+
+
+def test_overwrites_existing_file(tmp_path):
+    out = tmp_path / "x.md"
+    out.write_text("old", encoding="utf-8")
+    atomic_write_text(out, "new")
+    assert out.read_text(encoding="utf-8") == "new"
+
+
+def test_refuses_pre_existing_symlink(tmp_path):
+    target = tmp_path / "real.md"
+    target.write_text("victim", encoding="utf-8")
+    link = tmp_path / "out.md"
+    os.symlink(target, link)
+    with pytest.raises(ValueError, match="symlink"):
+        atomic_write_text(link, "evil")
+    assert target.read_text(encoding="utf-8") == "victim"
+
+
+def test_no_partial_file_on_exception(tmp_path, monkeypatch):
+    out = tmp_path / "x.md"
+
+    def boom(*_a, **_kw):
+        raise OSError("disk full")
+
+    monkeypatch.setattr("any2md.utils.os.replace", boom)
+    with pytest.raises(OSError):
+        atomic_write_text(out, "hello")
+    assert not out.exists()
+    leftovers = list(tmp_path.glob(".any2md-*.tmp"))
+    assert leftovers == []
+
+
+def test_creates_parent_dir_if_missing(tmp_path):
+    out = tmp_path / "deep" / "nested" / "x.md"
+    atomic_write_text(out, "hi")
+    assert out.read_text(encoding="utf-8") == "hi"

--- a/tests/unit/test_config_walkup.py
+++ b/tests/unit/test_config_walkup.py
@@ -1,0 +1,53 @@
+"""Tests for discover_config boundary behavior (F3)."""
+
+from __future__ import annotations
+
+from any2md.config import discover_config
+
+
+def test_stops_at_git_root(tmp_path):
+    (tmp_path / ".any2md.toml").write_text("[meta]\n", encoding="utf-8")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    sub = repo / "sub"
+    sub.mkdir()
+    assert discover_config(start=sub) is None
+
+
+def test_stops_at_pyproject_toml(tmp_path):
+    (tmp_path / ".any2md.toml").write_text("[meta]\n", encoding="utf-8")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").write_text("[project]\n", encoding="utf-8")
+    sub = repo / "sub"
+    sub.mkdir()
+    assert discover_config(start=sub) is None
+
+
+def test_finds_config_inside_project(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+    (repo / ".any2md.toml").write_text("[meta]\n", encoding="utf-8")
+    sub = repo / "sub"
+    sub.mkdir()
+    found = discover_config(start=sub)
+    assert found == (repo / ".any2md.toml").resolve()
+
+
+def test_returns_none_when_no_config(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / "pyproject.toml").touch()
+    assert discover_config(start=repo) is None
+
+
+def test_honors_explicit_boundary_marker(tmp_path):
+    (tmp_path / ".any2md.toml").write_text("[meta]\n", encoding="utf-8")
+    inner = tmp_path / "inner"
+    inner.mkdir()
+    (inner / ".any2md.toml.boundary").touch()
+    sub = inner / "sub"
+    sub.mkdir()
+    assert discover_config(start=sub) is None

--- a/tests/unit/test_heuristics.py
+++ b/tests/unit/test_heuristics.py
@@ -6,9 +6,7 @@ See spec §4 (heuristics module contract) and plan Batch A.
 from __future__ import annotations
 
 import socket
-from io import BytesIO
 from unittest.mock import MagicMock, patch
-from urllib.error import HTTPError, URLError
 
 import pytest
 
@@ -427,7 +425,9 @@ class _FakeResponse:
         return self._body
 
 
-def _safe_fetch_returning(body: bytes, headers: dict | None = None, err: str | None = None):
+def _safe_fetch_returning(
+    body: bytes, headers: dict | None = None, err: str | None = None
+):
     """Helper: build a stub safe_fetch() returning the given tuple."""
     return lambda *a, **kw: (body, headers or {}, err)
 

--- a/tests/unit/test_heuristics.py
+++ b/tests/unit/test_heuristics.py
@@ -427,14 +427,16 @@ class _FakeResponse:
         return self._body
 
 
+def _safe_fetch_returning(body: bytes, headers: dict | None = None, err: str | None = None):
+    """Helper: build a stub safe_fetch() returning the given tuple."""
+    return lambda *a, **kw: (body, headers or {}, err)
+
+
 class TestArxivLookup:
     def test_successful_response_returns_metadata(self):
-        with (
-            patch("socket.getaddrinfo", _public_ip_addrinfo),
-            patch(
-                "urllib.request.urlopen",
-                return_value=_FakeResponse(_ARXIV_SAMPLE_XML),
-            ),
+        with patch(
+            "any2md._http.safe_fetch",
+            _safe_fetch_returning(_ARXIV_SAMPLE_XML),
         ):
             result = heuristics.arxiv_lookup("2501.17755")
         assert result is not None
@@ -449,16 +451,11 @@ class TestArxivLookup:
         def fake_add_warnings(ws):
             warnings_collected.append(list(ws))
 
-        err = HTTPError(
-            "https://export.arxiv.org/api/query?id_list=bad",
-            404,
-            "Not Found",
-            {},
-            BytesIO(b""),
-        )
         with (
-            patch("socket.getaddrinfo", _public_ip_addrinfo),
-            patch("urllib.request.urlopen", side_effect=err),
+            patch(
+                "any2md._http.safe_fetch",
+                _safe_fetch_returning(None, None, "HTTP 404"),
+            ),
             patch(
                 "any2md.converters.add_warnings",
                 fake_add_warnings,
@@ -480,10 +477,9 @@ class TestArxivLookup:
             warnings_collected.append(list(ws))
 
         with (
-            patch("socket.getaddrinfo", _public_ip_addrinfo),
             patch(
-                "urllib.request.urlopen",
-                side_effect=URLError("timed out"),
+                "any2md._http.safe_fetch",
+                _safe_fetch_returning(None, None, "fetch error: timed out"),
             ),
             patch(
                 "any2md.converters.add_warnings",
@@ -504,7 +500,7 @@ class TestArxivLookup:
             return [(socket.AF_INET, socket.SOCK_STREAM, 6, "", ("127.0.0.1", 0))]
 
         with (
-            patch("socket.getaddrinfo", private_addrinfo),
+            patch("any2md._http.socket.getaddrinfo", private_addrinfo),
             patch(
                 "any2md.converters.add_warnings",
                 fake_add_warnings,
@@ -524,10 +520,9 @@ class TestArxivLookup:
             warnings_collected.append(list(ws))
 
         with (
-            patch("socket.getaddrinfo", _public_ip_addrinfo),
             patch(
-                "urllib.request.urlopen",
-                return_value=_FakeResponse(b"<not valid xml"),
+                "any2md._http.safe_fetch",
+                _safe_fetch_returning(b"<not valid xml"),
             ),
             patch(
                 "any2md.converters.add_warnings",
@@ -544,10 +539,9 @@ class TestArxivLookup:
         """Verify that the warning channel is the converters.add_warnings hook."""
         mock_hook = MagicMock()
         with (
-            patch("socket.getaddrinfo", _public_ip_addrinfo),
             patch(
-                "urllib.request.urlopen",
-                side_effect=URLError("boom"),
+                "any2md._http.safe_fetch",
+                _safe_fetch_returning(None, None, "fetch error: boom"),
             ),
             patch(
                 "any2md.converters.add_warnings",

--- a/tests/unit/test_http_safe.py
+++ b/tests/unit/test_http_safe.py
@@ -1,0 +1,206 @@
+"""Unit tests for any2md._http (URL validation + SSRF-safe fetcher)."""
+
+from __future__ import annotations
+
+import io
+import socket
+import urllib.error
+from email.message import Message
+from typing import Iterable
+
+import pytest
+
+from any2md._http import (
+    _MAX_REDIRECT_HOPS,
+    _MAX_RESPONSE_BYTES,
+    safe_fetch,
+    validate_url,
+)
+
+
+def _stub_dns(monkeypatch, mapping: dict[str, str]) -> None:
+    """Make socket.getaddrinfo return mapping[host] for any lookup."""
+
+    def fake(host, *args, **kwargs):
+        ip = mapping.get(host, "1.1.1.1")  # default: a public IP
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (ip, 0))]
+
+    monkeypatch.setattr("any2md._http.socket.getaddrinfo", fake)
+
+
+# ---------- validate_url ----------
+
+
+@pytest.mark.parametrize(
+    "ip,expect_disallowed",
+    [
+        ("127.0.0.1", True),
+        ("10.0.0.1", True),
+        ("192.168.1.1", True),
+        ("169.254.169.254", True),  # AWS metadata
+        ("::1", True),
+        ("8.8.8.8", False),
+        ("1.1.1.1", False),
+    ],
+)
+def test_validate_url_ip_classification(monkeypatch, ip, expect_disallowed):
+    _stub_dns(monkeypatch, {"x.example": ip})
+    err = validate_url("https://x.example/")
+    if expect_disallowed:
+        assert err is not None and "disallowed" in err
+    else:
+        assert err is None
+
+
+def test_validate_url_rejects_non_http_scheme(monkeypatch):
+    err = validate_url("ftp://example.com/")
+    assert err and "scheme" in err
+
+
+def test_validate_url_rejects_file_scheme(monkeypatch):
+    err = validate_url("file:///etc/passwd")
+    assert err and "scheme" in err
+
+
+def test_validate_url_no_hostname(monkeypatch):
+    err = validate_url("http:///path-only")
+    assert err and "hostname" in err
+
+
+def test_validate_url_unresolvable(monkeypatch):
+    def boom(*_a, **_kw):
+        raise socket.gaierror("nodename nor servname provided")
+
+    monkeypatch.setattr("any2md._http.socket.getaddrinfo", boom)
+    err = validate_url("https://does-not-exist.invalid/")
+    assert err and "resolve" in err
+
+
+# ---------- safe_fetch redirect walking ----------
+
+
+class _FakeHTTPResponse:
+    def __init__(self, body: bytes, headers: dict[str, str] | None = None):
+        self._body = body
+        self._buf = io.BytesIO(body)
+        msg = Message()
+        for k, v in (headers or {}).items():
+            msg[k] = v
+        self.headers = msg
+
+    def read(self, n: int | None = None) -> bytes:
+        return self._buf.read(n) if n is not None else self._buf.read()
+
+
+def _http_error(code: int, location: str | None = None) -> urllib.error.HTTPError:
+    msg = Message()
+    if location:
+        msg["Location"] = location
+    return urllib.error.HTTPError(
+        url="x", code=code, msg="redirect", hdrs=msg, fp=None
+    )
+
+
+class _FakeOpener:
+    def __init__(self, responses: Iterable):
+        self.responses = list(responses)
+        self.calls: list[str] = []
+
+    def open(self, req, timeout):
+        self.calls.append(req.full_url)
+        r = self.responses.pop(0)
+        if isinstance(r, urllib.error.HTTPError):
+            raise r
+        return r
+
+
+def _patch_opener(monkeypatch, opener: _FakeOpener) -> None:
+    monkeypatch.setattr(
+        "any2md._http.urllib.request.build_opener", lambda *_: opener
+    )
+
+
+def test_safe_fetch_simple_200(monkeypatch):
+    _stub_dns(monkeypatch, {"public.example": "1.1.1.1"})
+    opener = _FakeOpener([_FakeHTTPResponse(b"<html>ok</html>", {"X-Test": "1"})])
+    _patch_opener(monkeypatch, opener)
+    body, headers, err = safe_fetch("https://public.example/")
+    assert err is None
+    assert body == b"<html>ok</html>"
+    assert headers and headers.get("X-Test") == "1"
+    assert opener.calls == ["https://public.example/"]
+
+
+def test_safe_fetch_follows_redirect_within_limit(monkeypatch):
+    _stub_dns(monkeypatch, {"a.example": "1.1.1.1", "b.example": "2.2.2.2"})
+    opener = _FakeOpener(
+        [
+            _http_error(302, "https://b.example/"),
+            _FakeHTTPResponse(b"final"),
+        ]
+    )
+    _patch_opener(monkeypatch, opener)
+    body, _h, err = safe_fetch("https://a.example/")
+    assert err is None
+    assert body == b"final"
+    assert opener.calls == ["https://a.example/", "https://b.example/"]
+
+
+def test_safe_fetch_rejects_redirect_to_private(monkeypatch):
+    _stub_dns(
+        monkeypatch,
+        {"a.example": "1.1.1.1", "rebound.example": "169.254.169.254"},
+    )
+    opener = _FakeOpener([_http_error(302, "https://rebound.example/")])
+    _patch_opener(monkeypatch, opener)
+    body, _h, err = safe_fetch("https://a.example/")
+    assert body is None
+    assert err and "disallowed" in err
+
+
+def test_safe_fetch_max_hops(monkeypatch):
+    _stub_dns(monkeypatch, {f"h{i}.example": "1.1.1.1" for i in range(10)})
+    chain = [
+        _http_error(302, f"https://h{i + 1}.example/")
+        for i in range(_MAX_REDIRECT_HOPS + 2)
+    ]
+    opener = _FakeOpener(chain)
+    _patch_opener(monkeypatch, opener)
+    _b, _h, err = safe_fetch("https://h0.example/")
+    assert err and "too many redirects" in err.lower()
+
+
+def test_safe_fetch_loop_detection(monkeypatch):
+    _stub_dns(monkeypatch, {"loop.example": "1.1.1.1"})
+    opener = _FakeOpener([_http_error(302, "https://loop.example/")])
+    _patch_opener(monkeypatch, opener)
+    _b, _h, err = safe_fetch("https://loop.example/")
+    assert err and "loop" in err.lower()
+
+
+def test_safe_fetch_response_size_cap(monkeypatch):
+    _stub_dns(monkeypatch, {"big.example": "1.1.1.1"})
+    huge = b"x" * (_MAX_RESPONSE_BYTES + 100)
+    opener = _FakeOpener([_FakeHTTPResponse(huge)])
+    _patch_opener(monkeypatch, opener)
+    _b, _h, err = safe_fetch("https://big.example/")
+    assert err and "exceeds" in err
+
+
+def test_safe_fetch_head_method(monkeypatch):
+    _stub_dns(monkeypatch, {"head.example": "1.1.1.1"})
+    opener = _FakeOpener(
+        [_FakeHTTPResponse(b"", {"Last-Modified": "Wed, 01 Jan 2025 00:00:00 GMT"})]
+    )
+    _patch_opener(monkeypatch, opener)
+    _b, headers, err = safe_fetch("https://head.example/", method="HEAD")
+    assert err is None
+    assert headers and headers.get("Last-Modified")
+
+
+def test_safe_fetch_http_error_other(monkeypatch):
+    _stub_dns(monkeypatch, {"err.example": "1.1.1.1"})
+    opener = _FakeOpener([_http_error(500)])
+    _patch_opener(monkeypatch, opener)
+    _b, _h, err = safe_fetch("https://err.example/")
+    assert err and "500" in err

--- a/tests/unit/test_http_safe.py
+++ b/tests/unit/test_http_safe.py
@@ -96,9 +96,7 @@ def _http_error(code: int, location: str | None = None) -> urllib.error.HTTPErro
     msg = Message()
     if location:
         msg["Location"] = location
-    return urllib.error.HTTPError(
-        url="x", code=code, msg="redirect", hdrs=msg, fp=None
-    )
+    return urllib.error.HTTPError(url="x", code=code, msg="redirect", hdrs=msg, fp=None)
 
 
 class _FakeOpener:
@@ -115,9 +113,7 @@ class _FakeOpener:
 
 
 def _patch_opener(monkeypatch, opener: _FakeOpener) -> None:
-    monkeypatch.setattr(
-        "any2md._http.urllib.request.build_opener", lambda *_: opener
-    )
+    monkeypatch.setattr("any2md._http.urllib.request.build_opener", lambda *_: opener)
 
 
 def test_safe_fetch_simple_200(monkeypatch):

--- a/tests/unit/test_log_sanitizer.py
+++ b/tests/unit/test_log_sanitizer.py
@@ -1,0 +1,27 @@
+"""Tests for Docling-warning control-char sanitizer (F2)."""
+
+from __future__ import annotations
+
+from any2md.converters.docx import _sanitize_log_text
+
+
+def test_strips_ansi_escape():
+    s = "msg \x1b[31mRED\x1b[0m end"
+    assert _sanitize_log_text(s) == "msg [31mRED[0m end"
+
+
+def test_strips_null_byte():
+    assert _sanitize_log_text("a\x00b") == "ab"
+
+
+def test_preserves_printable_ascii():
+    s = "Plain ASCII text: hello, world! 123."
+    assert _sanitize_log_text(s) == s
+
+
+def test_preserves_tab_and_newline():
+    assert _sanitize_log_text("a\tb\nc") == "a\tb\nc"
+
+
+def test_strips_c1_controls():
+    assert _sanitize_log_text("a\x85b\x9fc") == "abc"

--- a/tests/unit/test_meta_reserved_keys.py
+++ b/tests/unit/test_meta_reserved_keys.py
@@ -1,0 +1,37 @@
+"""Tests for filter_reserved_overrides (F5: --meta integrity)."""
+
+from __future__ import annotations
+
+import pytest
+
+from any2md.frontmatter import _RESERVED_OVERRIDE_KEYS, filter_reserved_overrides
+
+
+@pytest.mark.parametrize("key", sorted(_RESERVED_OVERRIDE_KEYS))
+def test_each_reserved_key_dropped_with_warn(capsys, key):
+    out = filter_reserved_overrides({key: "x", "title": "ok"})
+    assert key not in out
+    assert out["title"] == "ok"
+    err = capsys.readouterr().err
+    assert key in err and "reserved" in err.lower()
+
+
+def test_non_reserved_keys_preserved(capsys):
+    overrides = {"title": "T", "authors": ["a"], "organization": "o"}
+    out = filter_reserved_overrides(overrides)
+    assert out == overrides
+    assert capsys.readouterr().err == ""
+
+
+def test_nested_dict_under_non_reserved_untouched():
+    overrides = {"generation_metadata": {"authored_by": "human"}}
+    out = filter_reserved_overrides(overrides)
+    assert out == overrides
+
+
+def test_none_passes_through():
+    assert filter_reserved_overrides(None) is None
+
+
+def test_empty_dict_passes_through():
+    assert filter_reserved_overrides({}) == {}

--- a/tests/unit/test_safe_dir_name.py
+++ b/tests/unit/test_safe_dir_name.py
@@ -1,0 +1,25 @@
+"""Tests for safe_dir_name (F11: PDF image dir hardening)."""
+
+from __future__ import annotations
+
+import pytest
+
+from any2md.utils import safe_dir_name
+
+
+@pytest.mark.parametrize(
+    "raw, expected",
+    [
+        ("normal-doc_v2", "normal-doc_v2"),
+        ("..", "untitled"),
+        ("...", "untitled"),
+        ("a/b/c", "a_b_c"),
+        ("hello world", "hello_world"),
+        ("", "untitled"),
+        ("___", "untitled"),
+        ("file.with.dots", "file_with_dots"),
+        ("emoji \U0001F4A9 here", "emoji_here"),
+    ],
+)
+def test_safe_dir_name(raw, expected):
+    assert safe_dir_name(raw) == expected

--- a/tests/unit/test_safe_dir_name.py
+++ b/tests/unit/test_safe_dir_name.py
@@ -18,7 +18,7 @@ from any2md.utils import safe_dir_name
         ("", "untitled"),
         ("___", "untitled"),
         ("file.with.dots", "file_with_dots"),
-        ("emoji \U0001F4A9 here", "emoji_here"),
+        ("emoji \U0001f4a9 here", "emoji_here"),
     ],
 )
 def test_safe_dir_name(raw, expected):

--- a/tests/unit/test_zipbomb_guard.py
+++ b/tests/unit/test_zipbomb_guard.py
@@ -1,0 +1,47 @@
+"""Tests for _safe_zip_open in any2md/converters/docx.py (F4)."""
+
+from __future__ import annotations
+
+import struct
+import zipfile
+from pathlib import Path
+
+import pytest
+
+from any2md.converters.docx import _MAX_DOCX_METADATA_SIZE, _safe_zip_open
+
+
+def _make_zip_with_lying_size(out: Path, member: str, declared_size: int):
+    """Build a zip whose ``member`` declares ``declared_size`` uncompressed.
+
+    We write a small real body, then mutate the central directory's
+    uncompressed-size field so ``ZipInfo.file_size`` reports the lie.
+    """
+    real_body = b"<x/>"
+    with zipfile.ZipFile(out, "w") as z:
+        z.writestr(member, real_body)
+    raw = out.read_bytes()
+    # Central directory entry signature is PK\x01\x02; uncompressed-size
+    # is at offset +24 (4 bytes, little-endian).
+    sig = b"PK\x01\x02"
+    idx = raw.find(sig)
+    assert idx != -1
+    raw = raw[: idx + 24] + struct.pack("<I", declared_size) + raw[idx + 28 :]
+    out.write_bytes(raw)
+
+
+def test_safe_zip_open_accepts_normal(tmp_path):
+    z = tmp_path / "ok.zip"
+    with zipfile.ZipFile(z, "w") as zf:
+        zf.writestr("a.xml", b"<x/>")
+    with zipfile.ZipFile(z) as zf:
+        f = _safe_zip_open(zf, "a.xml")
+        assert f.read() == b"<x/>"
+
+
+def test_safe_zip_open_rejects_oversized(tmp_path):
+    z = tmp_path / "bomb.zip"
+    _make_zip_with_lying_size(z, "core.xml", _MAX_DOCX_METADATA_SIZE + 1)
+    with zipfile.ZipFile(z) as zf:
+        with pytest.raises(ValueError, match="exceeds"):
+            _safe_zip_open(zf, "core.xml")


### PR DESCRIPTION
## Summary
Closes all 8 actionable findings from the 2026-04-27 multi-tool security audit (semgrep + trivy + gitleaks + bandit + pip-audit + manual review by the security-engineer agent + Opus 4.7). No public API changes; behavior unchanged for legitimate inputs.

## Highlights
- **F1 (HIGH)** — new \`any2md/_http.py\` with manual redirect walking + per-hop host revalidation; defeats DNS rebind and redirect-based SSRF.
- **F5 (MED)** — reserved-key filter so \`--meta content_hash=...\` etc. cannot forge derived frontmatter.
- **F3 (MED)** — TOML auto-discovery bounded at project markers; new \`--no-config\` flag.
- **F4 (MED)** — DOCX zip-bomb guard (1 MB cap on metadata members).
- **F-CVE** — bumps \`lxml\`/\`pillow\`/\`urllib3\` past known-CVE versions; adds upper bounds (compat envelope); pins \`requirements.txt\`.
- **F6/F2/F11** — atomic-write + symlink rejection, control-char sanitizer, PDF stem hardening.
- **XXE defense-in-depth** via \`defusedxml\`.

See \`docs/superpowers/specs/2026-04-27-v1.0.6-security-hardening-design.md\` for the full design and \`CHANGELOG.md\` for the per-fix table.

## Audit summary

| ID | Title | Severity |
|----|-------|----------|
| F1 | SSRF: DNS rebind + redirect bypass | High |
| F5 | \`--meta\` clobbers reserved frontmatter | Medium |
| F3 | TOML discovery walks above project root | Medium |
| F4 | DOCX zip-bomb amplification | Medium |
| F-CVE | Transitive deps with known CVEs | Medium |
| F6 | Symlink-following on output writes | Low |
| F2 | Control-char passthrough in Docling logs | Low |
| F11 | PDF stem \`..\` corner case | Low |

## Test plan
- [x] 7 new unit-test files (40 new tests).
- [x] 290 existing tests still pass; total 348 passed, 1 skipped.
- [x] \`ruff check .\` and \`ruff format --check .\` clean.
- [x] \`bandit -r any2md scripts\` went from 9 findings to 1 low (legitimate try/except/pass).
- [x] 5-DOCX acceptance run reproduces v1.0.5 word counts exactly (978/6726/15566/7811/1477) — fallback fires correctly with sanitized warnings.