### PR TITLE
v1.0.7: rebrand SSRM → SAGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.0.7] — 2026-04-29
+
+Branding/rebrand release. The frontmatter contract that any2md emits is
+now described as "SAGE-compatible" (Security Analysis and Guidance
+Exchange) — the upstream specification was renamed from SSRM (Structured
+Security Reasoning Markdown) to SAGE. No functional or schema changes:
+field names, ordering, controlled vocabularies, and `content_hash`
+derivation are byte-identical to v1.0.6. Existing v1.0.6 outputs remain
+valid SAGE-compatible documents without modification.
+
+### Changed
+
+- README, CHANGELOG, and all of `docs/` updated to reference SAGE /
+  Security Analysis and Guidance Exchange.
+- `--auto-id` CLI help text now reads "SAGE-conformant document_id"
+  (previously "SSRM-conformant"). Behavior unchanged.
+- Module/function docstrings in `any2md/frontmatter.py`,
+  `any2md/converters/txt.py`, and `any2md/pipeline/cleanup.py` updated
+  to reference SAGE §3 / §5.1 (same section numbers as the upstream
+  SSRM v1.0-RC1 spec).
+- Two test functions renamed for naming consistency
+  (`test_txt_end_to_end_writes_sage_compat_output`,
+  `test_compose_emits_required_sage_fields`). Pytest auto-discovery is
+  unaffected; assertions unchanged.
+
+### Migration
+
+None required. Public API, CLI flags, frontmatter shape, and
+`content_hash` outputs are all preserved bit-for-bit.
+
 ## [1.0.6] — 2026-04-27
 
 Security hardening release. Closes 8 actionable findings from the
@@ -318,7 +348,7 @@ Patch release. Adds an explicit backend-selection CLI flag.
 First stable release of any2md v1.0. Validated end-to-end against
 real-world documents (a 164-page PDF technical standard via Docling,
 a multi-page academic DOCX, and a Wikipedia article via trafilatura).
-The output contract — SSRM-compatible frontmatter, deterministic
+The output contract — SAGE-compatible frontmatter, deterministic
 `content_hash`, NFC + LF body normalization — is now stable. Downstream
 consumers can rely on this shape.
 
@@ -340,7 +370,7 @@ Phase 4: configuration, polish, and the v1.0 documentation set.
 - `--meta-file PATH` flag plus auto-discovery of `.any2md.toml` (walks up
   from cwd). The `[meta]` table supplies frontmatter overrides; the
   `[document_id]` table supplies `--auto-id` prefix and type code.
-- `--auto-id` flag — generates an SSRM-conformant `document_id` as
+- `--auto-id` flag — generates an SAGE-conformant `document_id` as
   `{PREFIX}-{YYYY}-{TYPE}-{SHA8}`. Defaults to `LOCAL`/`DOC`; override via
   the `[document_id]` table in `.any2md.toml`.
 - `--strict` flag — promotes pipeline validation warnings (heading
@@ -359,7 +389,7 @@ Phase 4: configuration, polish, and the v1.0 documentation set.
 - Comprehensive documentation set:
   - `README.md` rewritten with educational tone — every command preceded
     by why you'd run it and followed by what you'll see.
-  - `docs/output-format.md` — SSRM-compatible field reference and the
+  - `docs/output-format.md` — SAGE-compatible field reference and the
     `content_hash` recomputation recipe.
   - `docs/cli-reference.md` — flag-by-flag reference with use cases and a
     worked-example matrix.
@@ -462,14 +492,14 @@ any2md transparently falls back to pymupdf4llm (PDF) and mammoth (DOCX).
 
 First prerelease of any2md v1.0. Phase 1 of 5: foundation only — no Docling
 backend yet, no new CLI flags. Output frontmatter has been rewritten to be
-SSRM-compatible (Structured Security Reasoning Markdown) — this is a
+SAGE-compatible (Security Analysis and Guidance Exchange) — this is a
 breaking change for downstream consumers parsing v0.7 output. See
 `docs/superpowers/specs/2026-04-26-any2md-v1-design.md` for the full
 v1.0 design and `docs/superpowers/plans/2026-04-26-any2md-v1-phase1-foundation.md`
 for this phase's task plan.
 
 ### Added
-- New `any2md/frontmatter.py` module — SSRM-compatible YAML emitter with the
+- New `any2md/frontmatter.py` module — SAGE-compatible YAML emitter with the
   `SourceMeta` dataclass, deterministic `compute_content_hash`,
   `estimate_tokens`, `recommend_chunk_level`, `extract_abstract`, and
   `derive_title` helpers, plus the central `compose()` function (the only
@@ -495,7 +525,7 @@ for this phase's task plan.
   `reportlab`, `ruff`.
 
 ### Changed
-- **BREAKING:** Output frontmatter shape is now SSRM-compatible. New required
+- **BREAKING:** Output frontmatter shape is now SAGE-compatible. New required
   fields: `document_id` (empty string by default — opt-in via future
   `--auto-id`), `version`, `date`, `status: "draft"`, `document_type` (empty
   for non-security documents), `content_domain` (empty array),

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The full design rationale lives in [docs/superpowers/specs/2026-04-26-v1.0.3-emp
 
 ## What this is
 
-any2md ingests heterogeneous source documents and emits Markdown with a fixed YAML frontmatter contract. The frontmatter shape is SSRM-compatible (Structured Security Reasoning Markdown — a documented schema for LLM-consumable documents), so retrieval pipelines, embeddings jobs, and chunking utilities downstream can rely on field names, types, and a deterministic `content_hash` for cache invalidation. The body is NFC-normalized with LF line endings, and the heading hierarchy is guaranteed to start at H1 and not skip levels. The goal is one stable shape, regardless of whether a document started life as a scanned PDF, a Word doc, a Wikipedia page, or a plain text dump.
+any2md ingests heterogeneous source documents and emits Markdown with a fixed YAML frontmatter contract. The frontmatter shape is SAGE-compatible (Security Analysis and Guidance Exchange — a documented schema for LLM-consumable documents), so retrieval pipelines, embeddings jobs, and chunking utilities downstream can rely on field names, types, and a deterministic `content_hash` for cache invalidation. The body is NFC-normalized with LF line endings, and the heading hierarchy is guaranteed to start at H1 and not skip levels. The goal is one stable shape, regardless of whether a document started life as a scanned PDF, a Word doc, a Wikipedia page, or a plain text dump.
 
 ## Quick start
 
@@ -111,8 +111,8 @@ document_id: ""                                    # empty unless you pass --aut
 version: "1"                                       # "1" for source files without an embedded version
 date: "2026-03-15"                                 # docx core props "modified" → ISO-8601
 status: "draft"                                    # always "draft" for converted documents
-document_type: ""                                  # SSRM controlled vocab — empty for non-security docs
-content_domain: []                                 # SSRM controlled vocab — empty array when unknown
+document_type: ""                                  # SAGE controlled vocab — empty for non-security docs
+content_domain: []                                 # SAGE controlled vocab — empty array when unknown
 authors:                                           # extracted from docProps/core.xml dc:creator
   - "Rock Lambros"
 organization: ""                                   # docProps/app.xml Company; empty when absent
@@ -133,7 +133,7 @@ produced_by: "Microsoft® Word for Microsoft 365"   # software that produced the
 ---
 ```
 
-Fields under `# any2md extension field` are retained from v0.7 for traceability and observability — they're not part of the SSRM contract proper, but they live in the same frontmatter block. See [docs/output-format.md](docs/output-format.md) for the full field reference.
+Fields under `# any2md extension field` are retained from v0.7 for traceability and observability — they're not part of the SAGE contract proper, but they live in the same frontmatter block. See [docs/output-format.md](docs/output-format.md) for the full field reference.
 
 ### Before / after
 
@@ -329,7 +329,7 @@ You'll see the OK lines as if the conversion were fresh; previously-written outp
 
 ## The output format
 
-Every file converted by any2md has the same frontmatter shape, regardless of source format. The shape is **SSRM-compatible** — it matches the field names, types, and ordering of the Structured Security Reasoning Markdown specification, but values aren't required to match SSRM's controlled vocabularies (most converted documents aren't security research). Fields that require a controlled vocabulary (`document_type`, `content_domain`, `tlp`) are emitted empty unless you supply them via `--meta` or `.any2md.toml`.
+Every file converted by any2md has the same frontmatter shape, regardless of source format. The shape is **SAGE-compatible** — it matches the field names, types, and ordering of the Security Analysis and Guidance Exchange specification, but values aren't required to match SAGE's controlled vocabularies (most converted documents aren't security research). Fields that require a controlled vocabulary (`document_type`, `content_domain`, `tlp`) are emitted empty unless you supply them via `--meta` or `.any2md.toml`.
 
 ### Field auto-fill summary
 
@@ -374,7 +374,7 @@ You'll see the OK line as usual. The frontmatter of `Text/paper.md` will have `o
 
 ### `.any2md.toml`
 
-You'd use this when you have a stable set of frontmatter defaults that should apply to every conversion in a project. The file is auto-discovered by walking up from the current working directory, so you can drop one at the root of your corpus repo and forget about it. Worked example for a security-research org producing SSRM-conforming outputs:
+You'd use this when you have a stable set of frontmatter defaults that should apply to every conversion in a project. The file is auto-discovered by walking up from the current working directory, so you can drop one at the root of your corpus repo and forget about it. Worked example for a security-research org producing SAGE-conforming outputs:
 
 ```toml
 [meta]
@@ -528,7 +528,7 @@ The two-lane design exists because Docling output is layout-correct (running agg
 
 ## Migrating from v0.7
 
-v1.0 emits SSRM-compatible frontmatter — that's the one intended breaking change. v0.7's small frontmatter (`title`, `source_file`, `pages`, `type`, `word_count`) becomes a fuller block with `document_id`, `version`, `date`, `status`, `content_hash`, `token_estimate`, `authors`, and several other fields. The v0.7 fields are retained as any2md extension fields in the same block, so traceability is preserved, but downstream parsers that expected the old fixed shape will need to update. The body is now NFC-normalized with LF line endings, which means `content_hash` is reproducible. If you need bit-for-bit v0.7 output, pin `any2md==0.7.0`. The full field-by-field migration guide and behavior-change list lives in [docs/upgrading-from-0.7.md](docs/upgrading-from-0.7.md).
+v1.0 emits SAGE-compatible frontmatter — that's the one intended breaking change. v0.7's small frontmatter (`title`, `source_file`, `pages`, `type`, `word_count`) becomes a fuller block with `document_id`, `version`, `date`, `status`, `content_hash`, `token_estimate`, `authors`, and several other fields. The v0.7 fields are retained as any2md extension fields in the same block, so traceability is preserved, but downstream parsers that expected the old fixed shape will need to update. The body is now NFC-normalized with LF line endings, which means `content_hash` is reproducible. If you need bit-for-bit v0.7 output, pin `any2md==0.7.0`. The full field-by-field migration guide and behavior-change list lives in [docs/upgrading-from-0.7.md](docs/upgrading-from-0.7.md).
 
 ## Security
 

--- a/any2md/__init__.py
+++ b/any2md/__init__.py
@@ -1,3 +1,3 @@
 """Convert PDF, DOCX, HTML, and TXT files to LLM-optimized Markdown."""
 
-__version__ = "1.0.6"
+__version__ = "1.0.7"

--- a/any2md/cli.py
+++ b/any2md/cli.py
@@ -200,7 +200,7 @@ def main():
     parser.add_argument(
         "--auto-id",
         action="store_true",
-        help="Generate an SSRM-conformant document_id of the form "
+        help="Generate an SAGE-conformant document_id of the form "
         "{PREFIX}-{YYYY}-{TYPE}-{SHA8}. Defaults: PREFIX=LOCAL, TYPE=DOC. "
         "Override via .any2md.toml [document_id] (publisher_prefix, type_code).",
     )

--- a/any2md/converters/txt.py
+++ b/any2md/converters/txt.py
@@ -176,7 +176,7 @@ def convert_txt(
     force: bool = False,
     strip_links_flag: bool = False,
 ) -> bool:
-    """Convert a plain-text file to v1.0 SSRM-compatible Markdown."""
+    """Convert a plain-text file to v1.0 SAGE-compatible Markdown."""
     if options is None:
         options = PipelineOptions(strip_links=strip_links_flag)
 

--- a/any2md/frontmatter.py
+++ b/any2md/frontmatter.py
@@ -1,4 +1,4 @@
-"""SSRM-compatible YAML frontmatter emitter.
+"""SAGE-compatible YAML frontmatter emitter.
 
 See spec §3 (frontmatter contract) and §5.0 (SourceMeta dataclass).
 This module is the single producer of the YAML block — converters
@@ -60,7 +60,7 @@ def filter_reserved_overrides(
 
 
 def compute_content_hash(body: str) -> str:
-    """SHA-256 of NFC-normalized, LF-line-ended body. SSRM §5.1.
+    """SHA-256 of NFC-normalized, LF-line-ended body. SAGE §5.1.
 
     The body MUST be the post-pipeline output (after C1-C5). This function
     re-applies NFC and LF normalization defensively so callers can pass any
@@ -74,7 +74,7 @@ def compute_content_hash(body: str) -> str:
 def generate_document_id(
     body: str, prefix: str = "LOCAL", type_code: str = "DOC"
 ) -> str:
-    """Generate an SSRM-conformant ``document_id`` from body content.
+    """Generate an SAGE-conformant ``document_id`` from body content.
 
     Pattern: ``{PREFIX}-{YYYY}-{TYPE}-{SHA8}``.
 
@@ -227,7 +227,7 @@ def _normalize_body(body: str) -> str:
 def _build_fields(
     body: str, meta: SourceMeta, options: PipelineOptions
 ) -> dict[str, Any]:
-    """Build the ordered field map for the SSRM frontmatter block.
+    """Build the ordered field map for the SAGE frontmatter block.
 
     Returns an insertion-ordered dict matching spec §3.2-3.4. Only fields
     that should be emitted are present; conditional fields (e.g. ``pages``,
@@ -333,7 +333,7 @@ def _emit_field(key: str, value: Any, lines: list[str]) -> None:
             lines.append(f"  {subkey}: {_emit_value(subval)}")
         return
     if isinstance(value, list):
-        # Only string-lists are supported for now (matches SSRM §3 fields).
+        # Only string-lists are supported for now (matches SAGE §3 fields).
         lines.append(f"{key}: {_emit_array([str(v) for v in value])}")
         return
     if isinstance(value, (int, float)) and not isinstance(value, bool):
@@ -359,7 +359,7 @@ def compose(
     options: PipelineOptions,
     overrides: dict[str, Any] | None = None,
 ) -> str:
-    """Build a complete SSRM-compatible Markdown document.
+    """Build a complete SAGE-compatible Markdown document.
 
     Steps:
     1. Normalize body to NFC + LF endings (matches content_hash invariant).

--- a/any2md/pipeline/cleanup.py
+++ b/any2md/pipeline/cleanup.py
@@ -14,7 +14,7 @@ Stage = Callable[[str, "PipelineOptions"], str]
 
 
 def nfc_normalize(text: str, _options: "PipelineOptions") -> str:
-    """C1: NFC unicode normalization. Required by SSRM §5.1 for content_hash."""
+    """C1: NFC unicode normalization. Required by SAGE §5.1 for content_hash."""
     return unicodedata.normalize("NFC", text)
 
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -167,7 +167,7 @@ normalizations that any well-formed markdown can absorb without harm:
 Centralizing these means `content_hash` is byte-deterministic: the same
 post-cleanup body produces the same hash regardless of which lane ran first,
 because the cleanup is the last thing that touched the bytes. This is the
-determinism boundary the SSRM contract relies on.
+determinism boundary the SAGE contract relies on.
 
 ## Stage catalog
 
@@ -244,7 +244,7 @@ order.
 
 | Run order | ID | Name | Lane | Input shape | Output shape | No-op cases | Edge cases |
 |---|---|---|---|---|---|---|---|
-| 1 | C1 | `nfc_normalize` | shared | Any unicode text | NFC-normalized text | Already-NFC text | Required by SSRM `content_hash` invariant |
+| 1 | C1 | `nfc_normalize` | shared | Any unicode text | NFC-normalized text | Already-NFC text | Required by SAGE `content_hash` invariant |
 | 2 | C2 | `strip_soft_hyphens` | shared | Text containing U+00AD (`­`) | Text without U+00AD | No soft hyphens | Soft hyphens are invisible but token-costly |
 | 3 | C3 | `normalize_ligatures` | shared | Text containing presentation-form ligatures (`ﬁ`, `ﬂ`, `ﬃ`, `ﬄ`, `ﬅ`, `ﬆ`, `ﬀ`) and NBSP | Text with whitelist-expanded ligatures and regular spaces | None of the whitelist characters present | Whitelist-only — does not run blanket NFKC, which would fold superscripts and CJK compatibility characters |
 | 4 | C4 | `normalize_quotes_dashes` | shared | Smart quotes (`“”‘’`) and ellipsis (`…`) | Straight quotes (`""''`) and three-dot ellipsis | No smart quotes or ellipsis | En-dash and em-dash are preserved (semantic) |
@@ -305,7 +305,7 @@ class SourceMeta:
 
 ### Field-by-field
 
-| Field | Filled by | Required for SSRM contract |
+| Field | Filled by | Required for SAGE contract |
 |---|---|---|
 | `title_hint` | All converters when source metadata has a title (PDF `/Title`, DOCX `dc:title`, HTML `<title>`, otherwise `None`) | No — `frontmatter.derive_title` falls back to first H1, then filename |
 | `authors` | PDF (`/Author` parsed), DOCX (`dc:creator`), HTML (`<meta name="author">`), TXT (always `[]`). v1.0.2 adds body-text extraction and an arxiv API enrichment via `heuristics.extract_authors`. | No — empty `[]` is valid |
@@ -318,11 +318,11 @@ class SourceMeta:
 | `source_file` | All file inputs; URL inputs `None` | No — extension field |
 | `source_url` | URL inputs only; file inputs `None` | No — extension field |
 | `doc_type` | All converters | Yes — emitted as `type` in the YAML |
-| `extracted_via` | All converters | Yes — non-SSRM extension but required for traceability |
+| `extracted_via` | All converters | Yes — non-SAGE extension but required for traceability |
 | `lane` | All converters | Yes — drives pipeline routing |
 
 The four "required" fields above are required for the v1.0 contract to be
-fillable, not for SSRM strict conformance. Strict SSRM has a different
+fillable, not for SAGE strict conformance. Strict SAGE has a different
 required-fields list — see [output-format.md](output-format.md) for that
 distinction.
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -268,7 +268,7 @@ that defines what each key means.
 
 ### `--auto-id`
 
-Generate an SSRM-conformant `document_id` of the form
+Generate an SAGE-conformant `document_id` of the form
 `{PREFIX}-{YYYY}-{TYPE}-{SHA8}`. Defaults: `PREFIX=LOCAL`, `TYPE=DOC`. Override
 via `[document_id]` in `.any2md.toml` (`publisher_prefix`, `type_code`).
 

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -33,8 +33,8 @@ because every field in this document has a derivation rule that's tested.
 
 ## The SAGE connection
 
-any2md's frontmatter is **SAGE-compatible**. SAGE (Structured Security
-Reasoning Markdown) is a documented schema for LLM-consumable security
+any2md's frontmatter is **SAGE-compatible**. SAGE (Security Analysis
+and Guidance Exchange) is a documented schema for LLM-consumable security
 research documents — its primary audience is producers of threat intelligence
 and security guidance who want a stable shape for downstream RAG and LLM
 analysis. SAGE v1.0-RC1 is the version this contract tracks.

--- a/docs/output-format.md
+++ b/docs/output-format.md
@@ -31,22 +31,22 @@ non-empty, single-line, and YAML-escaped. None of those guarantees come free —
 they exist because every any2md output goes through the same final emitter and
 because every field in this document has a derivation rule that's tested.
 
-## The SSRM connection
+## The SAGE connection
 
-any2md's frontmatter is **SSRM-compatible**. SSRM (Structured Security
+any2md's frontmatter is **SAGE-compatible**. SAGE (Structured Security
 Reasoning Markdown) is a documented schema for LLM-consumable security
 research documents — its primary audience is producers of threat intelligence
 and security guidance who want a stable shape for downstream RAG and LLM
-analysis. SSRM v1.0-RC1 is the version this contract tracks.
+analysis. SAGE v1.0-RC1 is the version this contract tracks.
 
 "Compatible" rather than "strict" because most documents any2md converts are
-not security research. SSRM has fields with controlled vocabularies —
+not security research. SAGE has fields with controlled vocabularies —
 `document_type`, `content_domain`, `tlp`, `frameworks_referenced` — that don't
-have plausible defaults for an arbitrary PDF or web page. Strict SSRM
+have plausible defaults for an arbitrary PDF or web page. Strict SAGE
 validators reject empty or unknown values for those fields. any2md's choice is
 to emit the fields with empty defaults (`""` or `[]`) and `status: "draft"`, so
-the output is machine-readable in the SSRM shape but doesn't claim to be a
-finished SSRM document. If you produce real SSRM-conforming security research,
+the output is machine-readable in the SAGE shape but doesn't claim to be a
+finished SAGE document. If you produce real SAGE-conforming security research,
 populate those fields explicitly via [`--meta` or `.any2md.toml`](cli-reference.md#configuration-meta-and-meta-file).
 
 The fields below are grouped: identity, classification, provenance, integrity,
@@ -134,15 +134,15 @@ records when any2md wrote it).
 
 **auto** | type: `string` (controlled vocabulary)
 
-**Derivation:** Always `"draft"` for converted documents. SSRM allows
+**Derivation:** Always `"draft"` for converted documents. SAGE allows
 non-controlled-vocab values for other fields when `status` is `"draft"`, which
 is why this is the default — it's how an any2md output declares "I have an
-SSRM-compatible shape but I have not been authored as SSRM."
+SAGE-compatible shape but I have not been authored as SAGE."
 
 **Example:** `"draft"`
 
 **Common mistake:** Overriding to `"published"` via `--meta` for documents
-that haven't actually been reviewed. SSRM consumers may treat
+that haven't actually been reviewed. SAGE consumers may treat
 `status: "published"` as a signal that the controlled-vocabulary fields are
 trustworthy. Don't claim a status the content doesn't earn.
 
@@ -150,7 +150,7 @@ trustworthy. Don't claim a status the content doesn't earn.
 
 **user** | type: `string` (controlled vocabulary or empty)
 
-**Derivation:** Empty `""` by default. SSRM defines a controlled vocabulary
+**Derivation:** Empty `""` by default. SAGE defines a controlled vocabulary
 (e.g. `"guidance"`, `"vuln_advisory"`, `"threat_report"`) but any2md cannot
 infer it from a generic document.
 
@@ -161,7 +161,7 @@ infer it from a generic document.
 
 **user** | type: `array<string>`
 
-**Derivation:** Empty `[]` by default. SSRM controlled vocabulary
+**Derivation:** Empty `[]` by default. SAGE controlled vocabulary
 (e.g. `"ai_security"`, `"cloud"`, `"identity"`).
 
 **Example empty:** `[]`
@@ -199,7 +199,7 @@ otherwise empty. User overrides commonly set this for corpus-wide attribution.
 **auto** | type: `object` (`{authored_by: string}` minimum)
 
 **Derivation:** Always emitted with `authored_by: "unknown"` because any2md
-converts content; it does not author it. SSRM's `generation_metadata` block
+converts content; it does not author it. SAGE's `generation_metadata` block
 exists to record who or what produced the document (a human, a model, a
 collaboration). If you ran any2md as part of an authoring workflow, override
 the value via `--meta generation_metadata.authored_by=human`.
@@ -218,8 +218,8 @@ generation_metadata:
 ```
 
 **Common mistake:** Adding fields under `generation_metadata` and expecting
-SSRM validators to accept them. The SSRM schema for this block has its own
-shape — consult the SSRM specification before adding non-standard subfields.
+SAGE validators to accept them. The SAGE schema for this block has its own
+shape — consult the SAGE specification before adding non-standard subfields.
 
 ### `content_hash`
 
@@ -300,7 +300,7 @@ that.
 
 **user** | type: `array<string>` and `string`
 
-**Derivation:** Empty by default. SSRM-specific fields (security frameworks
+**Derivation:** Empty by default. SAGE-specific fields (security frameworks
 the document references; traffic-light-protocol marking). User-supplied via
 `--meta` or `.any2md.toml`.
 
@@ -660,7 +660,7 @@ tampered with after generation.
 This schema describes the v1.0 frontmatter block. Conditional fields
 (`keywords`, `abstract_for_rag`, `pages`, `word_count`, `source_file`,
 `source_url`, `produced_by`) are documented here as optional; they're omitted
-from the frontmatter when not set. SSRM-only fields a user might add (`tlp`,
+from the frontmatter when not set. SAGE-only fields a user might add (`tlp`,
 `frameworks_referenced`, etc.) are listed as additional valid fields.
 
 ```json
@@ -799,7 +799,7 @@ from the frontmatter when not set. SSRM-only fields a user might add (`tlp`,
 
 The schema sets `additionalProperties: true` because users add fields via
 `--meta` and `.any2md.toml` that are not part of the v1.0 contract. A stricter
-schema for SSRM-conforming outputs would set this to `false` and add the SSRM
+schema for SAGE-conforming outputs would set this to `false` and add the SAGE
 controlled-vocabulary constraints to `document_type`, `content_domain`, and
 related fields. Use this schema as a starting point for downstream validation
 and tighten it for your environment.

--- a/docs/superpowers/plans/2026-04-26-any2md-v1-phase1-foundation.md
+++ b/docs/superpowers/plans/2026-04-26-any2md-v1-phase1-foundation.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Restructure any2md into the v1.0 architecture (centralized frontmatter + pipeline + SourceMeta) and rewire all 4 existing converters through it without changing extraction backends. End state: every output file carries SSRM-compatible frontmatter with deterministic `content_hash`, body is NFC-normalized + LF-ended, and a `1.0.0a1` prerelease lands on TestPyPI.
+**Goal:** Restructure any2md into the v1.0 architecture (centralized frontmatter + pipeline + SourceMeta) and rewire all 4 existing converters through it without changing extraction backends. End state: every output file carries SAGE-compatible frontmatter with deterministic `content_hash`, body is NFC-normalized + LF-ended, and a `1.0.0a1` prerelease lands on TestPyPI.
 
 **Architecture:** Two-lane post-processing pipeline (structured / text), shared cleanup stages always last, single YAML emitter (`frontmatter.py`). In Phase 1 the structured lane is empty (no Docling yet) and the text lane is empty (T1–T6 land in Phase 3); only the shared cleanup C1–C7 runs.
 
@@ -736,7 +736,7 @@ Expected: FAIL with `ModuleNotFoundError: any2md.frontmatter`.
 - [ ] **Step 3: Create `any2md/frontmatter.py` skeleton**
 
 ```python
-"""SSRM-compatible YAML frontmatter emitter.
+"""SAGE-compatible YAML frontmatter emitter.
 
 See spec §3 (frontmatter contract) and §5.0 (SourceMeta dataclass).
 This module is the single producer of the YAML block — converters
@@ -842,7 +842,7 @@ Stage = Callable[[str, "PipelineOptions"], str]
 
 
 def nfc_normalize(text: str, _options: "PipelineOptions") -> str:
-    """C1: NFC unicode normalization. Required by SSRM §5.1 for content_hash."""
+    """C1: NFC unicode normalization. Required by SAGE §5.1 for content_hash."""
     return unicodedata.normalize("NFC", text)
 
 
@@ -1502,7 +1502,7 @@ git commit -m "feat(pipeline): C7 validate (read-only, emits warnings)"
 
 ```python
 # tests/unit/test_content_hash.py
-"""Tests for content_hash determinism (SSRM §5.1)."""
+"""Tests for content_hash determinism (SAGE §5.1)."""
 
 from any2md.frontmatter import compute_content_hash
 
@@ -1557,7 +1557,7 @@ import unicodedata
 
 
 def compute_content_hash(body: str) -> str:
-    """SHA-256 of NFC-normalized, LF-line-ended body. SSRM §5.1.
+    """SHA-256 of NFC-normalized, LF-line-ended body. SAGE §5.1.
 
     The body MUST be the post-pipeline output (after C1–C5). This function
     re-applies NFC and LF normalization defensively so callers can pass any
@@ -1898,7 +1898,7 @@ git commit -m "feat(frontmatter): derive_title with H1/hint/filename fallback ch
 
 ---
 
-## Task 21: Frontmatter `compose()` — full SSRM-compatible YAML emitter
+## Task 21: Frontmatter `compose()` — full SAGE-compatible YAML emitter
 
 **Files:**
 - Modify: `any2md/frontmatter.py`
@@ -1908,7 +1908,7 @@ git commit -m "feat(frontmatter): derive_title with H1/hint/filename fallback ch
 
 ```python
 # tests/unit/test_frontmatter_compose.py
-"""Tests for frontmatter.compose() — SSRM-compatible output."""
+"""Tests for frontmatter.compose() — SAGE-compatible output."""
 
 from datetime import date
 
@@ -1945,7 +1945,7 @@ def _meta(**overrides) -> SourceMeta:
     return SourceMeta(**base)
 
 
-def test_compose_emits_required_ssrm_fields():
+def test_compose_emits_required_sage_fields():
     body = "# Title\n\nbody\n"
     out = compose(body, _meta(), PipelineOptions())
     fm, _ = _split_frontmatter(out)
@@ -2092,7 +2092,7 @@ def _emit_array(values: list[str]) -> str:
 
 
 def compose(body: str, meta: SourceMeta, options: PipelineOptions) -> str:
-    """Build a complete SSRM-compatible Markdown document.
+    """Build a complete SAGE-compatible Markdown document.
 
     Steps:
     1. Normalize body to NFC + LF endings (matches content_hash invariant).
@@ -2117,7 +2117,7 @@ def compose(body: str, meta: SourceMeta, options: PipelineOptions) -> str:
     today = _date_cls.today().isoformat()
     fm_date = meta.date or today
 
-    # 3. Emit YAML in SSRM-defined order
+    # 3. Emit YAML in SAGE-defined order
     lines: list[str] = ["---"]
     lines.append(f"title: {_emit_value(title)}")
     lines.append('document_id: ""')
@@ -2163,7 +2163,7 @@ Expected: all PASS.
 
 ```bash
 git add any2md/frontmatter.py tests/unit/test_frontmatter_compose.py
-git commit -m "feat(frontmatter): compose() SSRM-compatible YAML emitter"
+git commit -m "feat(frontmatter): compose() SAGE-compatible YAML emitter"
 ```
 
 ---
@@ -2283,7 +2283,7 @@ from any2md.cli import main
 from any2md.pipeline import PipelineOptions
 
 
-def test_txt_end_to_end_writes_ssrm_compat_output(fixture_dir, tmp_output_dir, monkeypatch):
+def test_txt_end_to_end_writes_sage_compat_output(fixture_dir, tmp_output_dir, monkeypatch):
     monkeypatch.setattr(
         "sys.argv",
         ["any2md", "-o", str(tmp_output_dir), str(fixture_dir / "ligatures_and_softhyphens.txt")],
@@ -2478,7 +2478,7 @@ def convert_txt(
     force: bool = False,
     strip_links_flag: bool = False,
 ) -> bool:
-    """Convert a plain-text file to v1.0 SSRM-compatible Markdown."""
+    """Convert a plain-text file to v1.0 SAGE-compatible Markdown."""
     if options is None:
         options = PipelineOptions(strip_links=strip_links_flag)
 
@@ -3467,7 +3467,7 @@ echo
 echo "Outputs:"
 ls -la "$OUT_DIR"
 echo
-echo "Inspect each for: SSRM frontmatter, content_hash present, body NFC + LF, no garbled chars."
+echo "Inspect each for: SAGE frontmatter, content_hash present, body NFC + LF, no garbled chars."
 ```
 
 - [ ] **Step 2: Make executable + run**
@@ -3600,12 +3600,12 @@ Replace the `## [Unreleased]` heading and contents with:
 
 This is the first prerelease of any2md v1.0. Phase 1 of 5: foundation only.
 No Docling, no new CLI flags. Output frontmatter has been rewritten to be
-SSRM-compatible — this is a breaking change for downstream consumers
+SAGE-compatible — this is a breaking change for downstream consumers
 parsing v0.7 output. See `docs/superpowers/specs/2026-04-26-any2md-v1-design.md`
 for the full v1.0 design.
 
 ### Added
-- New `any2md/frontmatter.py` module (SSRM-compatible YAML emitter, `SourceMeta`).
+- New `any2md/frontmatter.py` module (SAGE-compatible YAML emitter, `SourceMeta`).
 - New `any2md/pipeline/` package with shared cleanup stages C1–C7
   (NFC normalization, soft-hyphen strip, ligature normalization,
   quote/dash normalization, whitespace collapse, footnote-marker strip,
@@ -3615,7 +3615,7 @@ for the full v1.0 design.
 - pytest test suite covering pipeline, frontmatter, validators, and per-format integration.
 
 ### Changed
-- **BREAKING:** Output frontmatter shape is SSRM-compatible. New required fields:
+- **BREAKING:** Output frontmatter shape is SAGE-compatible. New required fields:
   `document_id` (empty), `version`, `date`, `status: "draft"`, `document_type` (empty),
   `content_domain`, `authors`, `organization`, `generation_metadata`, `content_hash`.
   `source_file`, `pages`, `word_count`, and `type` are retained as any2md
@@ -3715,7 +3715,7 @@ PYTHONPATH=/tmp/any2md_test_install python -m any2md \
 head -20 /tmp/any2md_smoke/web_page.md
 ```
 
-Expected: help text shows; web_page.md has SSRM-compat frontmatter.
+Expected: help text shows; web_page.md has SAGE-compat frontmatter.
 
 - [ ] **Step 8: Final commit (none needed — everything already committed)**
 
@@ -3763,7 +3763,7 @@ Approximate critical path: A → C → D/E → F → G → H → I = 12 sequenti
 ## Self-review summary
 
 Spec coverage:
-- §3 Frontmatter contract → Tasks 8, 16–22 (full SSRM-compat shape, content_hash, all derivation helpers).
+- §3 Frontmatter contract → Tasks 8, 16–22 (full SAGE-compat shape, content_hash, all derivation helpers).
 - §4 Pipeline (C1–C7) → Tasks 9–15. Text/structured lanes registered empty in Task 7 (Phase 2/3 fill them).
 - §5 Per-format converters → Tasks 23–26 (TXT, HTML, DOCX, PDF). Phase 1 PDF is pymupdf4llm only.
 - §6 CLI → Task 27 preserves v0.7 flags routing through new pipeline. New flags are Phase 4.

--- a/docs/superpowers/plans/2026-04-26-any2md-v1-phase4-polish-config-docs.md
+++ b/docs/superpowers/plans/2026-04-26-any2md-v1-phase4-polish-config-docs.md
@@ -255,7 +255,7 @@ def test_custom_prefix_and_type_code():
 from datetime import date as _date_cls
 
 def generate_document_id(body: str, prefix: str = "LOCAL", type_code: str = "DOC") -> str:
-    """Generate an SSRM-conformant document_id from body content.
+    """Generate an SAGE-conformant document_id from body content.
 
     Pattern: {PREFIX}-{YYYY}-{TYPE}-{SHA8}
     Used by --auto-id. The SHA8 is the first 8 hex chars of the
@@ -642,12 +642,12 @@ Skeleton with section-by-section directives (the implementer fills with prose):
 1. **Title + tagline** (2 lines).
 2. **One-paragraph what+why** (4 sentences max). Explain RAG framing: "structured, machine-consumable Markdown for downstream retrieval pipelines."
 3. **Quick start** (3 commands, copy-paste): install, convert a file, convert a URL. Show the YAML frontmatter snippet of an output file.
-4. **Why any2md** section. The RAG ingestion problem in one paragraph (heterogeneous source formats; LLMs need stable shape; ad-hoc converters lose tables/structure). What "structured, machine-consumable Markdown" means here (SSRM-compatible frontmatter, deterministic content_hash, chunk-friendly heading hierarchy). Honest comparison table vs unstructured.io / pdfplumber / pandoc — ~3-4 rows, no marketing.
+4. **Why any2md** section. The RAG ingestion problem in one paragraph (heterogeneous source formats; LLMs need stable shape; ad-hoc converters lose tables/structure). What "structured, machine-consumable Markdown" means here (SAGE-compatible frontmatter, deterministic content_hash, chunk-friendly heading hierarchy). Honest comparison table vs unstructured.io / pdfplumber / pandoc — ~3-4 rows, no marketing.
 5. **What you get** section. Annotated frontmatter example: a real output file with one-line comments after each frontmatter field explaining what it is and why. Before/after example: snippet of a multi-column PDF as raw extraction (pymupdf4llm-style) vs as any2md output (Docling structured lane). Token-estimate / chunking guidance: "we recommend `recommended_chunk_level: h2` when sections are < 1500 tokens; `h3` otherwise."
 6. **Installation** section. Two paths: `pip install any2md` (lightweight: pymupdf4llm fallback only) vs `pip install "any2md[high-fidelity]"` (Docling: ~2 GB ML models, 3-10× slower, far better tables/multi-column). "When do I need high-fidelity?" 3-question decision tree (does my corpus have tables? multi-column? scanned PDFs?).
 7. **Usage by source type** section. Subsections for PDFs (digital vs scanned subsection), DOCX, HTML/URL (with the SSRF + size limits noted), TXT, batch/directory mode (with `-r` recursive). Each subsection: "why you'd use this" + command + "what you'll see".
-8. **The output format** subsection. Brief summary of SSRM-compat. Field auto-fill table (which fields are derived; which need user input). Link to `docs/output-format.md` for full reference.
-9. **Configuration** section. `--meta KEY=VAL` and `.any2md.toml` worked example. Show a 10-line `.any2md.toml` for a security-research org producing SSRM-conforming outputs.
+8. **The output format** subsection. Brief summary of SAGE-compat. Field auto-fill table (which fields are derived; which need user input). Link to `docs/output-format.md` for full reference.
+9. **Configuration** section. `--meta KEY=VAL` and `.any2md.toml` worked example. Show a 10-line `.any2md.toml` for a security-research org producing SAGE-conforming outputs.
 10. **Troubleshooting (link)** with 5 most common artifacts as one-line entries.
 11. **Architecture (link)** with the two-lane pipeline diagram inline (ASCII art from spec §2.1).
 12. **Migrating from v0.7** (link to docs/upgrading-from-0.7.md) with one-paragraph migration summary.
@@ -666,7 +666,7 @@ Commit: `docs: Rewrite README for v1.0 with educational tone and full output doc
 **File:** `docs/output-format.md`. Sections per spec §7.3:
 
 - **Why a contract.** RAG pipelines need a stable schema; cost of ad-hoc.
-- **The SSRM connection.** What SSRM is. Why we're compatible-not-strict (most converted docs aren't security research). Link to upstream SSRM-Specification-v1.0-RC1 (note: it lives in this repo's `template/` dir but `template/` is gitignored locally; reference by URL once SSRM is published, or embed the relevant section here).
+- **The SAGE connection.** What SAGE is. Why we're compatible-not-strict (most converted docs aren't security research). Link to upstream SAGE-Specification-v1.0-RC1 (note: it lives in this repo's `template/` dir but `template/` is gitignored locally; reference by URL once SAGE is published, or embed the relevant section here).
 - **Field-by-field reference.** Every required + optional + extension field. Per field: meaning, type, derivation rule (or "user-provided"), when it's empty, an example value, a "common mistake" callout. Use a definition list or a table.
 - **The body shape.** Single-H1 rule, no skipped levels, citation `[1][2]` format, table format, footnote conventions. Worked example: short input, full output.
 - **`content_hash` semantics.** Exact normalization recipe (NFC, LF, post-pipeline). 6-line Python snippet that recomputes it given a `.md` file:
@@ -694,7 +694,7 @@ ok = check_content_hash_round_trip(body, frontmatter_hash)
 
 - **JSON Schema** for the frontmatter. Auto-generated or hand-written; ~80-100 lines.
 
-Commit: `docs: docs/output-format.md - SSRM-compat field reference and content_hash semantics`
+Commit: `docs: docs/output-format.md - SAGE-compat field reference and content_hash semantics`
 
 ---
 
@@ -727,7 +727,7 @@ Commit: `docs: docs/cli-reference.md - flag-by-flag reference with use cases`
 - High-level pipeline diagram (ASCII art, same as spec §2.1).
 - Why two lanes — concrete damage example: "Running text-lane line-wrap repair on Docling table output produces this kind of corruption: …" with 5-line before/after.
 - Stage catalog — every stage's contract (one row per stage in a table: name, lane, input shape, output shape, no-op cases, edge cases).
-- The `SourceMeta` dataclass — what each field means, which converters populate it, which are required for the SSRM contract.
+- The `SourceMeta` dataclass — what each field means, which converters populate it, which are required for the SAGE contract.
 - Adding a new converter — step-by-step, ending in "the converter must produce raw markdown + SourceMeta and declare a lane. Frontmatter and cleanup are not its job."
 - Adding a new pipeline stage — where to insert (which file/lane), naming convention, test requirements.
 - Performance model — where time goes per format. Why Docling is slower (ML models). Where the optimization opportunities are.
@@ -760,13 +760,13 @@ Commit: `docs: docs/troubleshooting.md - symptom-cause-fix triage guide`
 
 **File:** `docs/upgrading-from-0.7.md`. Sections per spec §7.7:
 
-1. **TL;DR.** v1.0 emits SSRM-compatible frontmatter. Body is NFC + LF normalized. Pin v0.7 if you need the old shape.
+1. **TL;DR.** v1.0 emits SAGE-compatible frontmatter. Body is NFC + LF normalized. Pin v0.7 if you need the old shape.
 2. **Frontmatter field map** — table of v0.7 keys → v1.0 keys with notes:
 
 | v0.7 | v1.0 | Notes |
 |---|---|---|
 | `title` | `title` | unchanged |
-| `source_file` | `source_file` (extension) | retained as non-SSRM extension |
+| `source_file` | `source_file` (extension) | retained as non-SAGE extension |
 | `source_url` | `source_url` (extension) | retained, URL inputs only |
 | `pages` | `pages` (extension) | retained, PDF only |
 | `word_count` | `word_count` (extension) | retained |
@@ -832,7 +832,7 @@ Phase 4: configuration, polish, and the v1.0 documentation set.
 ### Added
 - `--meta KEY=VAL` repeatable flag for frontmatter overrides.
 - `--meta-file PATH` flag plus auto-discovery of `.any2md.toml` (walks up from cwd).
-- `--auto-id` flag — generates SSRM-conformant `document_id` as `LOCAL-{YYYY}-DOC-{SHA8}`. Override prefix/type via `[document_id]` table in `.any2md.toml`.
+- `--auto-id` flag — generates SAGE-conformant `document_id` as `LOCAL-{YYYY}-DOC-{SHA8}`. Override prefix/type via `[document_id]` table in `.any2md.toml`.
 - `--strict` flag — promotes pipeline validation warnings to errors.
 - `--quiet` / `-q` and `--verbose` / `-v` flags.
 - New exit code contract: 0 success, 1 usage/install error, 2 file failure, 3 strict-mode warning.
@@ -840,7 +840,7 @@ Phase 4: configuration, polish, and the v1.0 documentation set.
 - New module `any2md/config.py` for TOML config discovery and parsing.
 - Comprehensive documentation set under `docs/`:
   - `README.md` (rewritten)
-  - `docs/output-format.md` — SSRM-compat field reference and content_hash recipe.
+  - `docs/output-format.md` — SAGE-compat field reference and content_hash recipe.
   - `docs/cli-reference.md` — flag-by-flag with use cases.
   - `docs/architecture.md` — pipeline internals and contributor guide.
   - `docs/troubleshooting.md` — symptom-cause-fix table.

--- a/docs/superpowers/specs/2026-04-26-any2md-v1-design.md
+++ b/docs/superpowers/specs/2026-04-26-any2md-v1-design.md
@@ -13,30 +13,30 @@
 ### 1.1 Goals
 
 1. **Eliminate conversion artifacts** that currently degrade output quality: garbled / missing text, lost tables and images, erratic reading order in multi-column documents, broken lines from PDF wrap-extraction, font-encoding artifacts (ligatures, soft hyphens, CID-font glyphs).
-2. **Emit SSRM-compatible Markdown** — frontmatter shape and body conventions matching the `template/SSRM-Specification-v1.0-RC1.md` template in this repo, populated according to a documented derivation contract.
+2. **Emit SAGE-compatible Markdown** — frontmatter shape and body conventions matching the `template/SAGE-Specification-v1.0-RC1.md` template in this repo, populated according to a documented derivation contract.
 3. **Optimize the output for RAG and context engineering** — minimize file size and total tokens while remaining lossless on semantically meaningful content.
 4. **Update all GitHub-facing documentation** to be deeply educational, not just reference.
 5. **Ship as `1.0.0`** to PyPI (and TestPyPI for pre-release validation), signaling a stable RAG-ingestion contract.
 
 ### 1.2 Non-goals (deferred)
 
-- SSRM `signature` block (key management out of scope for a CLI tool in v1.0).
+- SAGE `signature` block (key management out of scope for a CLI tool in v1.0).
 - MkDocs / Sphinx site (GitHub-rendered Markdown only).
 - New input formats beyond PDF / DOCX / HTML / URL / TXT (no XLSX, PPTX, EPUB, RTF).
 - LLM-generated `abstract_for_rag` (heuristic is sufficient for v1.0).
-- Strict SSRM conformance for non-security documents (we emit *compatible* shape, not strict validation).
+- Strict SAGE conformance for non-security documents (we emit *compatible* shape, not strict validation).
 - A `--dry-run` mode.
 
 ### 1.3 Locked decisions (from brainstorm Q&A)
 
 | # | Decision | Choice |
 |---|---|---|
-| Q1 | SSRM conformance | **B — SSRM-compatible.** Same field shape; auto-fill what's truthful; leave domain-specific vocab fields empty; emit `status: "draft"`. |
+| Q1 | SAGE conformance | **B — SAGE-compatible.** Same field shape; auto-fill what's truthful; leave domain-specific vocab fields empty; emit `status: "draft"`. |
 | Q2 | PDF backend | **B1 + extras_require.** Docling primary; pymupdf4llm fallback when Docling not installed. Install via `pip install any2md[high-fidelity]`. Clear install hint when artifact-prone PDF detected without Docling. |
 | Q3 | DOCX/HTML/TXT backends | **A.** Per-format best-of-breed: PDF → Docling, DOCX → Docling, HTML/URL → trafilatura, TXT → heuristic. trafilatura output goes through the same shared post-processing as everything else. |
 | Q4 | Image / figure handling | **B by default** (caption only). `--ocr-figures` enables Tesseract OCR inside figures. `--save-images` writes image files to a sidecar dir and links them. |
 | Q5a | Token-minimization aggressiveness | **Aggressive** (default). Lossless cleanup including TOC dedupe and footnote-marker stripping. |
-| Q5b | Auto-derived SSRM fields | Auto: `content_hash`, `token_estimate`, `recommended_chunk_level`, `abstract_for_rag` (≥500 tok docs), `date`, `authors` (when extractable), `status: draft`. Opt-in: `document_id` via `--auto-id`. Empty: `document_type`, `content_domain`, `frameworks_referenced`, `tlp` (controlled vocabulary — not derivable). |
+| Q5b | Auto-derived SAGE fields | Auto: `content_hash`, `token_estimate`, `recommended_chunk_level`, `abstract_for_rag` (≥500 tok docs), `date`, `authors` (when extractable), `status: draft`. Opt-in: `document_id` via `--auto-id`. Empty: `document_type`, `content_domain`, `frameworks_referenced`, `tlp` (controlled vocabulary — not derivable). |
 | Arch | Implementation shape | **Approach 1 + two-lane pipeline.** Functional `str → str` stages composed in fixed order. Two lanes (structured / text) merge into shared cleanup. |
 
 ---
@@ -97,7 +97,7 @@
         └────────────┬────────────┘
                      │
         ┌────────────┴────────────┐
-        │     frontmatter.py      │   SSRM-compatible
+        │     frontmatter.py      │   SAGE-compatible
         │  - merge user overrides │   YAML emitter
         │  - derive title/date/…  │
         │  - compute content_hash │
@@ -114,7 +114,7 @@
 any2md/
   cli.py                         (extended: new flags)
   utils.py                       (slimmed: most logic moves out)
-  frontmatter.py                 (new: SSRM-compat YAML emitter, SourceMeta)
+  frontmatter.py                 (new: SAGE-compat YAML emitter, SourceMeta)
   pipeline/                      (new package)
     __init__.py                  (run(text, lane, options))
     structured.py                (Docling-lane stages)
@@ -126,10 +126,10 @@ any2md/
     docx.py                      (rewritten: Docling primary)
     html.py                      (extended: post-processing applied)
     txt.py                       (extended: cleanup pass added)
-  validators.py                  (new, optional: SSRM-compat sanity warnings)
+  validators.py                  (new, optional: SAGE-compat sanity warnings)
 
 docs/
-  output-format.md               (new — SSRM-compat contract)
+  output-format.md               (new — SAGE-compat contract)
   cli-reference.md               (new — flag-by-flag with use cases)
   architecture.md                (new — pipeline internals)
   troubleshooting.md             (new — symptom → cause → fix)
@@ -153,14 +153,14 @@ pyproject.toml                   (extras_require, version 1.0.0)
 - **Each converter's job shrinks** to: produce raw markdown + a `SourceMeta` object. No frontmatter, no cleanup — both are centralized.
 - **Two pipeline lanes** because Docling-emitted markdown is layout-correct (don't run aggressive line-repair on it; tables would break); trafilatura/TXT/pymupdf4llm output benefits from heavier regex repair.
 - **Shared cleanup runs last on both lanes**, identical for every input format. This is where lossless normalization lives. It is the determinism boundary that makes `content_hash` reproducible.
-- **`frontmatter.py` is the only producer of the YAML block.** Centralizing this is what makes SSRM-compat output consistent across formats.
+- **`frontmatter.py` is the only producer of the YAML block.** Centralizing this is what makes SAGE-compat output consistent across formats.
 - **`SourceMeta` dataclass** carries per-converter signal (page count, word count, mtime, source URL, extracted authors) into `frontmatter.py` — converters no longer touch YAML.
 
 ---
 
-## 3. SSRM-compatible frontmatter contract
+## 3. SAGE-compatible frontmatter contract
 
-### 3.1 Required-by-SSRM, auto-populated
+### 3.1 Required-by-SAGE, auto-populated
 
 | Field | Source | Notes |
 |---|---|---|
@@ -169,12 +169,12 @@ pyproject.toml                   (extras_require, version 1.0.0)
 | `version` | `"1"` for source files (no embedded version found); from PDF metadata if present | String per spec. |
 | `date` | File `mtime` for local; HTTP `Last-Modified` for URL; today for TXT without mtime | ISO-8601 `YYYY-MM-DD`. |
 | `status` | `"draft"` always (locked from Q1 = B) | Conformant value. |
-| `document_type` | Empty `""` (controlled vocab — can't derive) | SSRM validators allow non-conforming when status=draft. |
+| `document_type` | Empty `""` (controlled vocab — can't derive) | SAGE validators allow non-conforming when status=draft. |
 | `content_domain` | Empty array `[]` | Controlled vocab — can't derive. |
 | `authors` | PDF `Author` / DOCX `creator` / HTML `<meta name="author">`; else `[]` | Array even if single author. |
 | `organization` | PDF/DOCX `Company` or HTML `og:site_name`; else `""` | |
 | `generation_metadata.authored_by` | `"unknown"` | Documented extension value with rationale: any2md only converts; original authorship is undetermined. |
-| `content_hash` | SHA-256 of NFC-normalized body, per SSRM §5.1 (LF line endings, NFC, hash bytes after the closing `---\n`) | Always auto-computed. 64-char lowercase hex. |
+| `content_hash` | SHA-256 of NFC-normalized body, per SAGE §5.1 (LF line endings, NFC, hash bytes after the closing `---\n`) | Always auto-computed. 64-char lowercase hex. |
 
 ### 3.2 Optional, auto-populated
 
@@ -186,7 +186,7 @@ pyproject.toml                   (extras_require, version 1.0.0)
 | `token_estimate` | `ceil(len(body_chars) / 4)` — 4 chars/token rough rule, no tiktoken dep |
 | `recommended_chunk_level` | `h3` if any H2 section's body has > 1500 estimated tokens (using the same `ceil(chars/4)` heuristic as `token_estimate`); else `h2` |
 | `abstract_for_rag` | First non-heading paragraph ≥ 80 chars after the H1, truncated to ≤ 400 chars at last sentence boundary. Skip emission if `token_estimate < 500`. |
-| `source_file` / `source_url` | Preserved from any2md's existing convention as **non-SSRM extension fields** in the same frontmatter block — needed for traceability. |
+| `source_file` / `source_url` | Preserved from any2md's existing convention as **non-SAGE extension fields** in the same frontmatter block — needed for traceability. |
 | `type`, `pages`, `word_count` | Retained as v0.7-compatible extension fields for traceability and observability. |
 
 ### 3.3 Worked example
@@ -200,7 +200,7 @@ document_id: ""                      # opt-in via --auto-id
 version: "1"
 date: "2026-03-15"                   # docx core props "modified"
 status: "draft"
-document_type: ""                    # SSRM-compat: empty for non-security docs
+document_type: ""                    # SAGE-compat: empty for non-security docs
 content_domain: []
 authors:
   - "Rock Lambros"                   # docx core props "creator"
@@ -227,7 +227,7 @@ word_count: 14289
 2. **`content_hash` is computed *after* all post-processing is finalized.** Any further edit invalidates the hash.
 3. **Body is NFC-normalized with LF line endings before hashing AND before writing to disk.** This makes recomputed hashes match.
 4. **The emitter is deterministic.** Same input + same flags → byte-identical output.
-5. **Field order in YAML matches SSRM §3.2 → §3.4 ordering.** Grouped: identity → classification → provenance → integrity → optional. Aids human diff/review.
+5. **Field order in YAML matches SAGE §3.2 → §3.4 ordering.** Grouped: identity → classification → provenance → integrity → optional. Aids human diff/review.
 6. **YAML escaping** is applied to every string field (existing `escape_yaml_string` covers it).
 7. **Empty arrays appear as `[]`, empty strings as `""`.** Never omit a required-by-shape field, even when value is empty (it's part of the contract).
 
@@ -257,8 +257,8 @@ Docling produces correctly-laid-out markdown — multi-column flow is already re
 |---|---|---|---|
 | S1 | `lift_figure_captions` | Convert Docling's `<figure>` blocks to `*Figure N: caption*` italic lines. Drops the `<img>` reference unless `--save-images` is set. | Caption-only mode (Q4 default = B). With `--ocr-figures`, append OCR'd text below the caption. |
 | S2 | `compact_tables` | Strip per-cell padding spaces inside GFM tables. Saves 5–8% on table-heavy docs. | Skip header alignment row to keep columns valid. |
-| S3 | `normalize_citations` | Coalesce `[1] [2]` → `[1][2]`; ensure citations live at clause-end before punctuation, per SSRM §4.3. | Light-touch; only acts on existing bracket numerals. |
-| S4 | `enforce_heading_hierarchy` | Guarantee single H1 (promote first heading if missing; demote subsequent H1s to H2). Ensure no skipped levels (H2 → H4 becomes H2 → H3 → H4). | Per SSRM §4.4. Emits validator warning when changes were applied. |
+| S3 | `normalize_citations` | Coalesce `[1] [2]` → `[1][2]`; ensure citations live at clause-end before punctuation, per SAGE §4.3. | Light-touch; only acts on existing bracket numerals. |
+| S4 | `enforce_heading_hierarchy` | Guarantee single H1 (promote first heading if missing; demote subsequent H1s to H2). Ensure no skipped levels (H2 → H4 becomes H2 → H3 → H4). | Per SAGE §4.4. Emits validator warning when changes were applied. |
 
 ### 4.2 TEXT lane (trafilatura, TXT, pymupdf4llm fallback, mammoth fallback)
 
@@ -275,11 +275,11 @@ This output may contain raw line-wrap artifacts, soft-hyphenation, web boilerpla
 
 ### 4.3 SHARED CLEANUP (always last; both lanes)
 
-Lossless normalization. Required by the SSRM `content_hash` invariant — the body must be NFC + LF before hashing.
+Lossless normalization. Required by the SAGE `content_hash` invariant — the body must be NFC + LF before hashing.
 
 | # | Stage | Purpose |
 |---|---|---|
-| C1 | `nfc_normalize` | `unicodedata.normalize("NFC", text)` — required by SSRM §5.1. |
+| C1 | `nfc_normalize` | `unicodedata.normalize("NFC", text)` — required by SAGE §5.1. |
 | C2 | `strip_soft_hyphens` | Remove U+00AD globally. Frequent PDF artifact, invisible but token-costly. |
 | C3 | `normalize_ligatures` | NFKC pass *only on letter-presentation forms*: `ﬁ→fi, ﬂ→fl, ﬃ→ffi, ﬄ→ffl`, plus ` →' '` (NBSP). Whitelist-driven. |
 | C4 | `normalize_quotes_dashes` | Smart quotes → straight; en/em-dash retained (semantic); ellipsis `…` → `...`. Saves ~1% on prose docs. |
@@ -704,7 +704,7 @@ Tone rule: every command in the README is preceded by *why you'd run it* and fol
 ### 7.3 docs/output-format.md sections
 
 - Why a contract.
-- The SSRM connection — what SSRM is, why we're compatible-not-strict, link to upstream spec.
+- The SAGE connection — what SAGE is, why we're compatible-not-strict, link to upstream spec.
 - Field-by-field reference (every field: meaning, type, derivation, when empty, example, common-mistake callout).
 - Body shape — single-H1 rule, citations, tables, footnotes; worked example showing 50-page PDF → markdown.
 - `content_hash` semantics — exact normalization recipe; 6-line Python snippet that recomputes it.
@@ -856,7 +856,7 @@ Five phases. Each ends with a TestPyPI alpha/beta tag. User can pause between an
 
 | Phase | Scope | Tag | TestPyPI? | PyPI? |
 |---|---|---|---|---|
-| **1 — Foundation** | New module layout (`frontmatter.py`, `pipeline/`); `SourceMeta` dataclass; all shared cleanup stages C1-C7; rewire all 4 converters through new pipeline (no Docling yet); SSRM-compat frontmatter for all formats; content_hash + token_estimate + chunk_level + abstract derivation; existing CLI flags continue to work; **`.gitignore` adds `template/` and `test_docs/`** | `1.0.0a1` | ✓ | — |
+| **1 — Foundation** | New module layout (`frontmatter.py`, `pipeline/`); `SourceMeta` dataclass; all shared cleanup stages C1-C7; rewire all 4 converters through new pipeline (no Docling yet); SAGE-compat frontmatter for all formats; content_hash + token_estimate + chunk_level + abstract derivation; existing CLI flags continue to work; **`.gitignore` adds `template/` and `test_docs/`** | `1.0.0a1` | ✓ | — |
 | **2 — Docling backend** | `extras_require = {"high-fidelity": ["docling>=2.0"]}`; PDF/DOCX Docling primary path; `pdf_looks_complex` heuristic; install-hint message; `--high-fidelity` flag; structured-lane stages S1-S4; integration tests skipped when Docling not installed | `1.0.0a2` | ✓ | — |
 | **3 — Figures / OCR / TXT cleanup** | Figure caption lift; `--ocr-figures`; `--save-images`; trafilatura post-processing wired; TXT lane through cleanup; metadata extraction (DOCX core props, PDF metadata, trafilatura `bare_extraction`, HTTP `Last-Modified`) | `1.0.0a3` | ✓ | — |
 | **4 — Polish, configuration, docs** | `--meta`, `--meta-file`, `.any2md.toml` discovery, `--auto-id`, `--strict`, `--quiet`, `--verbose`; new exit codes; full doc rewrite (README + 6 `docs/*.md` + CONTRIBUTING + 2 issue templates); CHANGELOG 1.0.0; editorial review pass | `1.0.0rc1` | ✓ | — |
@@ -917,12 +917,12 @@ None. All five clarifying questions and the architectural fork were resolved dur
 
 | Decision | Choice |
 |---|---|
-| SSRM conformance | B — SSRM-compatible |
+| SAGE conformance | B — SAGE-compatible |
 | PDF backend | B1 + extras_require |
 | DOCX/HTML/TXT backends | A (per-format best-of-breed) + uniform post-processing |
 | Image / figure handling | B default; `--ocr-figures` for C; `--save-images` for D |
 | Token minimization | Aggressive |
-| SSRM derived fields | Recommended defaults |
+| SAGE derived fields | Recommended defaults |
 | Implementation shape | Approach 1 + two-lane pipeline |
 | Version bump | MAJOR (0.7.0 → 1.0.0) |
 | Documentation requirement | All GitHub-facing docs deeply educational |

--- a/docs/upgrading-from-0.7.md
+++ b/docs/upgrading-from-0.7.md
@@ -17,7 +17,7 @@ surface, see [cli-reference.md](cli-reference.md).
 
 ## TL;DR
 
-- v1.0 emits **SSRM-compatible frontmatter**. The v0.7 frontmatter
+- v1.0 emits **SAGE-compatible frontmatter**. The v0.7 frontmatter
   (`title`, `source_file`, `pages`, `type`, `word_count`) becomes a fuller
   block with `document_id`, `version`, `date`, `status`, `content_hash`,
   `token_estimate`, `authors`, `organization`, `generation_metadata`,
@@ -48,10 +48,10 @@ v0.7 are listed in the second table.
 | v0.7 | v1.0 | Notes |
 |---|---|---|
 | `title` | `title` | Unchanged in semantics. v1.0 derivation is more robust: first H1, then source metadata title, then cleaned filename. |
-| `source_file` | `source_file` (extension) | Retained as a non-SSRM extension field for traceability. Conditional — emitted only for file inputs, not URLs. |
-| `source_url` | `source_url` (extension) | Retained as a non-SSRM extension field. Conditional — emitted only for URL inputs. |
-| `pages` | `pages` (extension) | Retained as a non-SSRM extension field. PDF inputs only; absent otherwise. |
-| `word_count` | `word_count` (extension) | Retained as a non-SSRM extension field. Set for DOCX, HTML, TXT; absent for PDF. |
+| `source_file` | `source_file` (extension) | Retained as a non-SAGE extension field for traceability. Conditional — emitted only for file inputs, not URLs. |
+| `source_url` | `source_url` (extension) | Retained as a non-SAGE extension field. Conditional — emitted only for URL inputs. |
+| `pages` | `pages` (extension) | Retained as a non-SAGE extension field. PDF inputs only; absent otherwise. |
+| `word_count` | `word_count` (extension) | Retained as a non-SAGE extension field. Set for DOCX, HTML, TXT; absent for PDF. |
 | `type` | `type` (extension) | Retained. v1.0 values are still `pdf` / `docx` / `html` / `txt`. |
 
 ### Keys new in v1.0
@@ -62,8 +62,8 @@ v0.7 are listed in the second table.
 | `version` | string | Always `"1"` for v1.0. Reserved for future revisions. |
 | `date` | string | ISO-8601 `YYYY-MM-DD`. Source-side metadata first, then file mtime, then today. |
 | `status` | string | Always `"draft"` for converted documents. |
-| `document_type` | string | Empty by default. SSRM controlled vocabulary; user-provided. |
-| `content_domain` | array | Empty `[]` by default. SSRM controlled vocabulary; user-provided. |
+| `document_type` | string | Empty by default. SAGE controlled vocabulary; user-provided. |
+| `content_domain` | array | Empty `[]` by default. SAGE controlled vocabulary; user-provided. |
 | `authors` | array | Auto-extracted from source metadata when present. Always an array, possibly `[]`. |
 | `organization` | string | Auto-extracted from source metadata when present. |
 | `generation_metadata` | object | At minimum `{authored_by: "unknown"}` for converted documents. |
@@ -74,8 +74,8 @@ v0.7 are listed in the second table.
 | `keywords` | array | Conditional — emitted only when at least one keyword was extracted. |
 | `extracted_via` | string | Records which backend produced the markdown (`docling`, `pymupdf4llm`, `mammoth+markdownify`, `trafilatura`, `trafilatura+bs4_fallback`, `heuristic`). |
 | `produced_by` | string | **New in v1.0.2.** Software that produced the source file (PDF `Creator`, DOCX `Application`). Conditional — emitted only when set, and typically empty when the source has a real `organization`. Distinct from `extracted_via`, which records the any2md backend. |
-| `frameworks_referenced` | array | Empty by default. SSRM extension; user-provided via `--meta`. |
-| `tlp` | string | Empty by default. SSRM marking; user-provided via `--meta`. |
+| `frameworks_referenced` | array | Empty by default. SAGE extension; user-provided via `--meta`. |
+| `tlp` | string | Empty by default. SAGE marking; user-provided via `--meta`. |
 
 For derivation rules and field semantics, see
 [output-format.md](output-format.md).

--- a/scripts/validate-phase1.sh
+++ b/scripts/validate-phase1.sh
@@ -29,4 +29,4 @@ echo
 echo "Outputs:"
 ls -la "$OUT_DIR"
 echo
-echo "Inspect each for: SSRM frontmatter, content_hash present, body NFC + LF, no garbled chars."
+echo "Inspect each for: SAGE frontmatter, content_hash present, body NFC + LF, no garbled chars."

--- a/tests/integration/test_txt.py
+++ b/tests/integration/test_txt.py
@@ -6,7 +6,7 @@ from any2md.converters.txt import convert_txt
 from any2md.pipeline import PipelineOptions
 
 
-def test_txt_end_to_end_writes_ssrm_compat_output(fixture_dir, tmp_output_dir):
+def test_txt_end_to_end_writes_sage_compat_output(fixture_dir, tmp_output_dir):
     ok = convert_txt(
         fixture_dir / "ligatures_and_softhyphens.txt",
         tmp_output_dir,

--- a/tests/unit/test_content_hash.py
+++ b/tests/unit/test_content_hash.py
@@ -1,4 +1,4 @@
-"""Tests for content_hash determinism (SSRM §5.1)."""
+"""Tests for content_hash determinism (SAGE §5.1)."""
 
 from any2md.frontmatter import compute_content_hash
 

--- a/tests/unit/test_frontmatter_compose.py
+++ b/tests/unit/test_frontmatter_compose.py
@@ -1,4 +1,4 @@
-"""Tests for frontmatter.compose() — SSRM-compatible output."""
+"""Tests for frontmatter.compose() — SAGE-compatible output."""
 
 import yaml
 
@@ -38,7 +38,7 @@ def _meta(**overrides) -> SourceMeta:
     return SourceMeta(**base)
 
 
-def test_compose_emits_required_ssrm_fields():
+def test_compose_emits_required_sage_fields():
     body = "# Title\n\nbody\n"
     out = compose(body, _meta(), PipelineOptions())
     fm, _ = _split_frontmatter(out)


### PR DESCRIPTION
## Summary

- Threads the upstream rename "Structured Security Reasoning Markdown" (SSRM) → "Security Analysis and Guidance Exchange" (SAGE) through README, CHANGELOG, all of `docs/`, `--auto-id` help text, module/function docstrings, and two test function names.
- Bumps `__version__` to `1.0.7`.
- **No functional or schema changes.** Frontmatter field names, ordering, controlled vocabularies, and `content_hash` derivation are byte-identical to v1.0.6. v1.0.6 outputs remain valid SAGE-compatible documents.

## Test plan

- [x] Full suite: `pytest tests/` — 348 passed, 1 skipped (pre-existing skip).
- [x] Two renamed test functions auto-discovered by pytest and pass.
- [ ] CI green on this PR before merge.
- [ ] After merge: tag `v1.0.7` from `main`, create GitHub release → triggers PyPI publish workflow.